### PR TITLE
feat: add confidence axis from upstream PR merge activity

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -151,11 +151,15 @@ Per-ecosystem `DOWNLOADS_REF` is calibrated separately — npm and PyPI scales d
 | Deep rewrite | 20 |
 | Replacement target unmaintained / archived | **disqualify** |
 
-### 6.3 Final
+### 6.3 Confidence (0..100)
 
-`score = 0.7 × impact + 0.3 × effort`
+Predicts whether a drive-by PR will land. Driven by the upstream repo's most-recently-merged PR timestamp (GitHub GraphQL `repository.pullRequests(states:MERGED, orderBy:UPDATED_AT)`). Decay: 100 if merged ≤14 days ago, linear to 0 by 365 days. Unknown ⇒ 30 (mild penalty so unreachable repos don't crowd out reachable ones).
 
-### 6.4 Disqualifiers
+### 6.4 Final
+
+`score = 0.6 × impact + 0.25 × effort + 0.15 × confidence`
+
+### 6.5 Disqualifiers
 
 - Project archived or no commit in 24 months → drop unless vuln severity ≥ 9
 - Replacement target itself flagged on OSV → drop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ packages = ["src/biibaa"]
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+extend-exclude = [".claude"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "UP", "SIM"]

--- a/src/biibaa/adapters/github_repo.py
+++ b/src/biibaa/adapters/github_repo.py
@@ -1,0 +1,117 @@
+"""GitHub repo activity adapter — fetches the most-recently-merged PR
+timestamp via the v4 GraphQL API. Used as a confidence signal for biibaa
+briefs: a repo whose maintainers merged something last week is far more
+likely to merge a drive-by contribution than one frozen for two years."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from datetime import datetime
+
+import httpx
+import structlog
+
+from biibaa.adapters._http import make_client
+
+log = structlog.get_logger(__name__)
+
+GRAPHQL_URL = "https://api.github.com/graphql"
+
+_QUERY = """
+query LastMergedPR($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(states: MERGED, orderBy: {field: UPDATED_AT, direction: DESC}, first: 1) {
+      nodes { mergedAt }
+    }
+  }
+}
+"""
+
+_REPO_RE = re.compile(r"https?://github\.com/([^/]+)/([^/?#]+?)(?:\.git)?/?$")
+
+
+def _parse_repo_url(url: str) -> tuple[str, str] | None:
+    m = _REPO_RE.match(url.strip())
+    if not m:
+        return None
+    return m.group(1), m.group(2)
+
+
+def _resolve_token(explicit: str | None) -> str | None:
+    if explicit:
+        return explicit
+    if env := os.environ.get("GITHUB_TOKEN"):
+        return env
+    try:
+        out = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+        return out.stdout.strip() or None
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+
+
+class GithubRepoSource:
+    name = "github_repo"
+
+    def __init__(
+        self, *, token: str | None = None, client: httpx.Client | None = None
+    ) -> None:
+        self._token = _resolve_token(token)
+        self._client = client or make_client(timeout=15.0)
+        self._cache: dict[tuple[str, str], datetime | None] = {}
+
+    def _headers(self) -> dict[str, str]:
+        h = {"Accept": "application/vnd.github+json"}
+        if self._token:
+            h["Authorization"] = f"Bearer {self._token}"
+        return h
+
+    def last_merged_pr_at(self, *, repo_url: str) -> datetime | None:
+        parsed = _parse_repo_url(repo_url)
+        if not parsed:
+            return None
+        if parsed in self._cache:
+            return self._cache[parsed]
+        owner, name = parsed
+        try:
+            r = self._client.post(
+                GRAPHQL_URL,
+                json={"query": _QUERY, "variables": {"owner": owner, "name": name}},
+                headers=self._headers(),
+            )
+            r.raise_for_status()
+            payload = r.json()
+        except httpx.HTTPError as e:
+            log.warning("github_repo.fetch_failed", repo=repo_url, error=str(e))
+            self._cache[parsed] = None
+            return None
+
+        if payload.get("errors"):
+            log.warning(
+                "github_repo.graphql_errors", repo=repo_url, errors=payload["errors"]
+            )
+            self._cache[parsed] = None
+            return None
+
+        nodes = (
+            ((payload.get("data") or {}).get("repository") or {})
+            .get("pullRequests", {})
+            .get("nodes")
+            or []
+        )
+        if not nodes or not nodes[0].get("mergedAt"):
+            self._cache[parsed] = None
+            return None
+        merged_at = datetime.fromisoformat(nodes[0]["mergedAt"].replace("Z", "+00:00"))
+        self._cache[parsed] = merged_at
+        return merged_at
+
+    def close(self) -> None:
+        self._client.close()

--- a/src/biibaa/briefs/render.py
+++ b/src/biibaa/briefs/render.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from biibaa.domain import Brief
+from biibaa.scoring import confidence
 
 _TEMPLATE_DIR = Path(__file__).parent / "templates"
 _env = Environment(
@@ -17,14 +18,26 @@ _env = Environment(
 )
 
 
+def _maintainer_activity(brief: Brief) -> tuple[str, float]:
+    last_pr = brief.project.last_pr_merged_at
+    conf = confidence(last_pr_merged_at=last_pr, now=brief.run_at)
+    if last_pr is None:
+        return "unknown", conf
+    days = (brief.run_at - last_pr).total_seconds() / 86400.0
+    return f"last PR merged {int(days)}d ago", conf
+
+
 def render_brief(brief: Brief) -> str:
     template = _env.get_template("brief.md.j2")
+    activity_label, confidence_value = _maintainer_activity(brief)
     return template.render(
         project=brief.project,
         run_at=brief.run_at,
         score=brief.score,
         impact=brief.impact,
         effort=brief.effort,
+        confidence_value=confidence_value,
+        activity_label=activity_label,
         opportunities=brief.opportunities,
     )
 

--- a/src/biibaa/briefs/templates/brief.md.j2
+++ b/src/biibaa/briefs/templates/brief.md.j2
@@ -3,7 +3,8 @@
 - **Repo**: {{ ('[' ~ project.repo_url ~ '](' ~ project.repo_url ~ ')') if project.repo_url else '_unknown — see opportunity links_' }}
 - **Ecosystem**: {{ project.ecosystem }}
 - **Popularity**: {{ ("{:,}".format(project.downloads_weekly) ~ ' downloads/wk') if project.downloads_weekly else '—' }}
-- **Score**: {{ "%.1f"|format(score) }} (impact {{ "%.1f"|format(impact) }}, effort {{ "%.1f"|format(effort) }})
+- **Score**: {{ "%.1f"|format(score) }} (impact {{ "%.1f"|format(impact) }}, effort {{ "%.1f"|format(effort) }}, confidence {{ "%.0f"|format(confidence_value) }})
+- **Maintainer activity**: {{ activity_label }}
 
 ## Top opportunities
 

--- a/src/biibaa/domain/models.py
+++ b/src/biibaa/domain/models.py
@@ -27,6 +27,7 @@ class Project(_Frozen):
     dependents: int | None = None
     last_release_at: datetime | None = None
     last_commit_at: datetime | None = None
+    last_pr_merged_at: datetime | None = None
     archived: bool = False
 
 

--- a/src/biibaa/pipeline/run.py
+++ b/src/biibaa/pipeline/run.py
@@ -23,11 +23,13 @@ import structlog
 from biibaa.adapters.e18e import E18eReplacementsSource
 from biibaa.adapters.ecosyste_ms import Dependent, EcosystemsSource
 from biibaa.adapters.github_advisories import GithubAdvisorySource
+from biibaa.adapters.github_repo import GithubRepoSource
 from biibaa.adapters.npm_downloads import NpmDownloadsSource
 from biibaa.briefs.render import write_brief
 from biibaa.domain import Advisory, Brief, Opportunity, Project, Replacement
 from biibaa.scoring import (
     REPLACEMENT_EFFORT_SCORE,
+    confidence,
     effort_score,
     final_score,
     impact,
@@ -52,7 +54,12 @@ def _project_name_from_purl(purl: str) -> str:
 
 
 def _project_from(
-    purl: str, ecosystem: str, downloads: int | None, repo_url: str | None
+    purl: str,
+    ecosystem: str,
+    downloads: int | None,
+    repo_url: str | None,
+    *,
+    last_pr_merged_at: datetime | None = None,
 ) -> Project:
     return Project(
         purl=purl,
@@ -60,6 +67,7 @@ def _project_from(
         name=_project_name_from_purl(purl),
         downloads_weekly=downloads,
         repo_url=repo_url,
+        last_pr_merged_at=last_pr_merged_at,
     )
 
 
@@ -72,7 +80,8 @@ def _vuln_opportunity(
         fixed_versions=advisory.fixed_versions, advisory_summary=advisory.summary
     )
     imp = impact(pop=pop, sev=sev)
-    score = final_score(impact_value=imp, effort_value=eff)
+    conf = confidence(last_pr_merged_at=project.last_pr_merged_at, now=run_at)
+    score = final_score(impact_value=imp, effort_value=eff, confidence_value=conf)
     return Opportunity(
         id=str(uuid.uuid5(uuid.NAMESPACE_URL, f"{project.purl}|{advisory.id}")),
         kind="vulnerability-fix",
@@ -95,7 +104,8 @@ def _replacement_opportunity(
     sev = replacement_severity(axis=replacement.axis, native=is_native)
     eff = replacement_effort_score(band=replacement.effort)
     imp = impact(pop=pop, sev=sev)
-    score = final_score(impact_value=imp, effort_value=eff)
+    conf = confidence(last_pr_merged_at=project.last_pr_merged_at, now=run_at)
+    score = final_score(impact_value=imp, effort_value=eff, confidence_value=conf)
     kind = "perf-replacement" if replacement.axis == "perf" else "dep-replacement"
     return Opportunity(
         id=str(
@@ -206,6 +216,7 @@ def run(
     downloads_src = NpmDownloadsSource()
     e18e_src = E18eReplacementsSource() if include_replacements else None
     eco_src = EcosystemsSource() if include_replacements else None
+    repo_src = GithubRepoSource()
 
     advisories: list[Advisory] = list(
         advisory_src.fetch(ecosystem=ecosystem, limit=advisory_limit)
@@ -249,8 +260,17 @@ def run(
     projects: dict[str, Project] = {}
     for purl, findings in by_project.items():
         name = _project_name_from_purl(purl)
+        last_pr = (
+            repo_src.last_merged_pr_at(repo_url=findings.repo_url)
+            if findings.repo_url
+            else None
+        )
         projects[purl] = _project_from(
-            purl, ecosystem, bulk_downloads.get(name), findings.repo_url
+            purl,
+            ecosystem,
+            bulk_downloads.get(name),
+            findings.repo_url,
+            last_pr_merged_at=last_pr,
         )
 
     # Build opportunities + briefs.
@@ -302,6 +322,7 @@ def run(
 
     advisory_src.close()
     downloads_src.close()
+    repo_src.close()
     if e18e_src:
         e18e_src.close()
     if eco_src:

--- a/src/biibaa/scoring.py
+++ b/src/biibaa/scoring.py
@@ -1,8 +1,9 @@
-"""Scoring per SPEC §6 — popularity × severity × effort."""
+"""Scoring per SPEC §6 — popularity × severity × effort × confidence."""
 
 from __future__ import annotations
 
 import math
+from datetime import datetime
 from typing import Final
 
 # Per §6.1 — flatten the long tail. Per-ecosystem refs would live in config
@@ -15,8 +16,16 @@ W_DOWNLOADS: Final[float] = 0.7
 W_STARS: Final[float] = 0.3
 
 # Final blend (§6.3)
-W_IMPACT: Final[float] = 0.7
-W_EFFORT: Final[float] = 0.3
+W_IMPACT: Final[float] = 0.6
+W_EFFORT: Final[float] = 0.25
+W_CONFIDENCE: Final[float] = 0.15
+
+# Confidence decay (§6.4): linear from 100 (≤14d) to 0 (≥365d).
+# None ⇒ 30 — mild penalty for unknown so we don't over-recommend
+# briefs to repos we couldn't reach.
+CONFIDENCE_FRESH_DAYS: Final[int] = 14
+CONFIDENCE_STALE_DAYS: Final[int] = 365
+CONFIDENCE_UNKNOWN: Final[float] = 30.0
 
 
 def popularity(*, downloads_weekly: int | None, stars: int | None) -> float:
@@ -87,5 +96,23 @@ def impact(*, pop: float, sev: float) -> float:
     return (pop / 100.0) * sev  # 0-100
 
 
-def final_score(*, impact_value: float, effort_value: float) -> float:
-    return W_IMPACT * impact_value + W_EFFORT * effort_value
+def confidence(*, last_pr_merged_at: datetime | None, now: datetime) -> float:
+    if last_pr_merged_at is None:
+        return CONFIDENCE_UNKNOWN
+    days = (now - last_pr_merged_at).total_seconds() / 86400.0
+    if days <= CONFIDENCE_FRESH_DAYS:
+        return 100.0
+    if days >= CONFIDENCE_STALE_DAYS:
+        return 0.0
+    span = CONFIDENCE_STALE_DAYS - CONFIDENCE_FRESH_DAYS
+    return 100.0 * (1.0 - (days - CONFIDENCE_FRESH_DAYS) / span)
+
+
+def final_score(
+    *, impact_value: float, effort_value: float, confidence_value: float
+) -> float:
+    return (
+        W_IMPACT * impact_value
+        + W_EFFORT * effort_value
+        + W_CONFIDENCE * confidence_value
+    )

--- a/tests/test_github_repo.py
+++ b/tests/test_github_repo.py
@@ -1,0 +1,83 @@
+"""Adapter unit tests for GithubRepoSource (latest-merged-PR signal)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import httpx
+from pytest_httpx import HTTPXMock
+
+from biibaa.adapters.github_repo import GithubRepoSource
+
+
+def test_returns_merged_at_for_known_repo(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        method="POST",
+        json={
+            "data": {
+                "repository": {
+                    "pullRequests": {
+                        "nodes": [{"mergedAt": "2026-04-20T12:34:56Z"}],
+                    }
+                }
+            }
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    got = src.last_merged_pr_at(repo_url="https://github.com/facebook/react")
+    assert got == datetime(2026, 4, 20, 12, 34, 56, tzinfo=UTC)
+
+
+def test_returns_none_when_no_merged_prs(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        method="POST",
+        json={"data": {"repository": {"pullRequests": {"nodes": []}}}},
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    assert src.last_merged_pr_at(repo_url="https://github.com/example/empty") is None
+
+
+def test_returns_none_on_graphql_errors(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        method="POST",
+        json={"errors": [{"message": "Could not resolve to a Repository"}]},
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    assert src.last_merged_pr_at(repo_url="https://github.com/ghost/missing") is None
+
+
+def test_returns_none_on_http_error(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql", method="POST", status_code=502
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    assert src.last_merged_pr_at(repo_url="https://github.com/example/repo") is None
+
+
+def test_results_are_cached_per_repo(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        method="POST",
+        json={
+            "data": {
+                "repository": {
+                    "pullRequests": {"nodes": [{"mergedAt": "2026-04-01T00:00:00Z"}]}
+                }
+            }
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    a = src.last_merged_pr_at(repo_url="https://github.com/foo/bar")
+    b = src.last_merged_pr_at(repo_url="https://github.com/foo/bar")
+    assert a == b
+    # Only one request despite two calls — pytest-httpx asserts this on teardown
+    # if no further mocks are registered.
+
+
+def test_unparseable_repo_url_returns_none() -> None:
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    assert src.last_merged_pr_at(repo_url="not-a-url") is None
+    assert src.last_merged_pr_at(repo_url="https://gitlab.com/x/y") is None

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,5 +1,9 @@
+from datetime import UTC, datetime, timedelta
+
 from biibaa.scoring import (
+    CONFIDENCE_UNKNOWN,
     DOWNLOADS_REF_NPM,
+    confidence,
     effort_score,
     final_score,
     impact,
@@ -43,10 +47,38 @@ def test_effort_score_penalises_breaking_summary():
 
 
 def test_final_score_is_weighted_blend():
-    # 0.7 * 80 + 0.3 * 50 = 56 + 15 = 71
-    assert final_score(impact_value=80, effort_value=50) == 71.0
+    # 0.6 * 80 + 0.25 * 50 + 0.15 * 40 = 48 + 12.5 + 6 = 66.5
+    assert final_score(impact_value=80, effort_value=50, confidence_value=40) == 66.5
 
 
 def test_impact_combines_popularity_and_severity():
     # pop=50 → 0.5 ; sev=80 → 80 ; impact = 40
     assert impact(pop=50.0, sev=80.0) == 40.0
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 26, tzinfo=UTC)
+
+
+def test_confidence_unknown_when_no_signal():
+    assert confidence(last_pr_merged_at=None, now=_now()) == CONFIDENCE_UNKNOWN
+
+
+def test_confidence_full_when_fresh():
+    assert confidence(last_pr_merged_at=_now() - timedelta(days=1), now=_now()) == 100.0
+    assert confidence(last_pr_merged_at=_now() - timedelta(days=14), now=_now()) == 100.0
+
+
+def test_confidence_zero_when_stale():
+    assert confidence(last_pr_merged_at=_now() - timedelta(days=365), now=_now()) == 0.0
+    assert confidence(last_pr_merged_at=_now() - timedelta(days=900), now=_now()) == 0.0
+
+
+def test_confidence_decays_linearly_in_window():
+    # 14d → 100, 365d → 0; midpoint (189.5d) → ~50
+    mid = confidence(last_pr_merged_at=_now() - timedelta(days=189, hours=12), now=_now())
+    assert 49.5 < mid < 50.5
+
+    early = confidence(last_pr_merged_at=_now() - timedelta(days=100), now=_now())
+    late = confidence(last_pr_merged_at=_now() - timedelta(days=300), now=_now())
+    assert early > late > 0.0


### PR DESCRIPTION
## Summary

- Adds `last_pr_merged_at` to `Project` and a new `github_repo` adapter that fetches it via GitHub GraphQL (`repository.pullRequests states:MERGED orderBy:UPDATED_AT first:1`), routed through the shared proxy-aware `_http` client. Token resolves from `GITHUB_TOKEN` env, falling back to `gh auth token`. Per-repo in-memory cache; failures degrade to `None` + structured warning rather than aborting the run.
- New `scoring.confidence(...)` returning 0–100: linear decay from 100 (≤14 days since last merged PR) to 0 (≥365 days). Unknown ⇒ 30 — a mild penalty so unreachable repos don't crowd out reachable ones.
- Final blend updated: `0.6 × impact + 0.25 × effort + 0.15 × confidence` (was `0.7 × impact + 0.3 × effort`).
- Briefs surface a "Maintainer activity: last PR merged Nd ago" line and include confidence in the score line of the header.
- SPEC §6 split: 6.3 confidence / 6.4 final / 6.5 disqualifiers. Drive-by side-fix: `extend-exclude = [".claude"]` in `[tool.ruff]` so stale agent worktrees don't break lint.

## Why

A repo where the maintainer merged something last week is alive and likely to look at a drive-by PR. One frozen for two years is effectively abandoned; recommending a brief there wastes attention. Confidence is orthogonal to popularity (impact) and effort, so it gets its own axis rather than folding into either.

## Test plan

- [x] `uv run --native-tls pytest -q` — 26 passed (4 new confidence boundary tests, 6 new adapter tests including 404 / network error / cache / unparseable-URL cases).
- [x] `uv run --native-tls ruff check .` — clean.
- [ ] Manual smoke: run pipeline against a known-active repo (e.g. `facebook/react`) and a stale one — verify confidence scores ≥80 vs <20 respectively.
