### PR TITLE
feat: pyoso-backed dependents fan-out + eligibility filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "structlog>=24.1",
 ]
 
+[project.optional-dependencies]
+pyoso = ["pyoso>=0.9"]
+
 [project.scripts]
 biibaa = "biibaa.cli.main:app"
 

--- a/src/biibaa/adapters/_circuit.py
+++ b/src/biibaa/adapters/_circuit.py
@@ -1,0 +1,81 @@
+"""In-process circuit breaker.
+
+Wraps a callable. After `failure_threshold` consecutive failures the breaker
+opens — subsequent calls return `fallback` immediately without invoking the
+underlying callable. After `reset_after` seconds the breaker half-opens and
+the next call probes; success closes it, failure re-opens for another window.
+
+Failures are detected via the supplied `is_failure` predicate over the result
+(default: any exception, or a falsy/empty list result). Useful for adapters
+where the underlying call swallows errors and returns `[]` on its own (the
+ecosyste.ms adapter does this) — we treat the empty result as the failure
+signal so the breaker can still open on a hot 500-ing endpoint.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+
+@dataclass
+class _State:
+    consecutive_failures: int = 0
+    opened_at: float | None = None
+
+
+class CircuitBreaker[T]:
+    def __init__(
+        self,
+        *,
+        name: str,
+        failure_threshold: int = 3,
+        reset_after_seconds: float = 60.0,
+        treat_empty_as_failure: bool = True,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.name = name
+        self._threshold = failure_threshold
+        self._reset_after = reset_after_seconds
+        self._treat_empty = treat_empty_as_failure
+        self._clock = clock
+        self._state = _State()
+
+    @property
+    def is_open(self) -> bool:
+        if self._state.opened_at is None:
+            return False
+        # Half-open: let the next call through to probe.
+        return (self._clock() - self._state.opened_at) < self._reset_after
+
+    def call(self, fn: Callable[[], T], *, fallback: T) -> T:
+        if self.is_open:
+            return fallback
+        try:
+            result = fn()
+        except Exception:
+            self._record_failure()
+            return fallback
+        if self._treat_empty and _is_empty(result):
+            self._record_failure()
+            return result
+        self._record_success()
+        return result
+
+    def _record_failure(self) -> None:
+        self._state.consecutive_failures += 1
+        if self._state.consecutive_failures >= self._threshold:
+            self._state.opened_at = self._clock()
+
+    def _record_success(self) -> None:
+        self._state = _State()
+
+
+def _is_empty(value: object) -> bool:
+    if value is None:
+        return True
+    try:
+        return len(value) == 0  # type: ignore[arg-type]
+    except TypeError:
+        return False

--- a/src/biibaa/adapters/dependents_cache.py
+++ b/src/biibaa/adapters/dependents_cache.py
@@ -1,0 +1,105 @@
+"""SQLite cache for dependents lookups.
+
+Keyed by (system, name, iso_week) — biibaa runs weekly, so this matches the
+underlying refresh cadence and lets us avoid hitting BigQuery / ecosyste.ms
+for the same seed twice in the same week.
+
+Schema is intentionally tiny — one row per cache hit holding the JSON-encoded
+dependents list. No migrations, no ORM. The cache is a HINT, not a system of
+record — every operation swallows OS/SQLite errors and logs them, so a
+disk-full or corrupted-DB condition doesn't crash a pipeline that just
+needs to fall through to live queries.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import sqlite3
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import structlog
+
+from biibaa.ports.dependents import Dependent
+
+log = structlog.get_logger(__name__)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS dependents_cache (
+  system TEXT NOT NULL,
+  name TEXT NOT NULL,
+  iso_week TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  written_at TEXT NOT NULL,
+  PRIMARY KEY (system, name, iso_week)
+)
+"""
+
+
+def _iso_week(now: datetime | None = None) -> str:
+    n = now or datetime.now(UTC)
+    y, w, _ = n.isocalendar()
+    return f"{y}-W{w:02d}"
+
+
+class DependentsCache:
+    def __init__(
+        self,
+        *,
+        path: Path,
+        clock: Callable[[], datetime] = lambda: datetime.now(UTC),
+    ) -> None:
+        self._conn: sqlite3.Connection | None = None
+        self._clock = clock
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(path)
+            self._conn.execute(_SCHEMA)
+            self._conn.commit()
+        except (sqlite3.Error, OSError) as e:
+            log.warning("dependents_cache.open_failed", path=str(path), error=str(e))
+            self._conn = None
+
+    def get(self, *, system: str, name: str) -> list[Dependent] | None:
+        if self._conn is None:
+            return None
+        try:
+            cur = self._conn.execute(
+                "SELECT payload FROM dependents_cache "
+                "WHERE system=? AND name=? AND iso_week=?",
+                (system, name, _iso_week(self._clock())),
+            )
+            row = cur.fetchone()
+        except (sqlite3.Error, OSError) as e:
+            log.warning("dependents_cache.get_failed", error=str(e))
+            return None
+        if row is None:
+            return None
+        return [Dependent(**d) for d in json.loads(row[0])]
+
+    def put(self, *, system: str, name: str, dependents: list[Dependent]) -> None:
+        if self._conn is None:
+            return
+        payload = json.dumps([d.__dict__ for d in dependents])
+        try:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO dependents_cache "
+                "(system, name, iso_week, payload, written_at) VALUES (?, ?, ?, ?, ?)",
+                (
+                    system,
+                    name,
+                    _iso_week(self._clock()),
+                    payload,
+                    self._clock().isoformat(),
+                ),
+            )
+            self._conn.commit()
+        except (sqlite3.Error, OSError) as e:
+            log.warning("dependents_cache.put_failed", error=str(e))
+
+    def close(self) -> None:
+        if self._conn is not None:
+            with contextlib.suppress(sqlite3.Error, OSError):
+                self._conn.close()

--- a/src/biibaa/adapters/dependents_factory.py
+++ b/src/biibaa/adapters/dependents_factory.py
@@ -1,0 +1,58 @@
+"""Build the right DependentsSource for the current environment.
+
+Preference order:
+  1. pyoso (`OSO_API_KEY` set + `pyoso` extra installed) — joins sboms_v0 +
+     repositories_v0, returns GitHub repos ranked by stars. The right
+     primary because deps.dev BigQuery `Dependents` is not clustered, so
+     per-package live queries scan ~500 GB / $2.59 each.
+  2. ecosyste.ms only — works for cold-tail packages but reliably 500s on
+     hot packages like lodash/debug/axios. Wrapped with a circuit breaker.
+
+Returns a TieredDependentsSource (cache → primary → ecosyste.ms fallback)
+when a primary is available, otherwise the bare ecosyste.ms adapter.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import structlog
+
+from biibaa.adapters.dependents_cache import DependentsCache
+from biibaa.adapters.dependents_tiered import TieredDependentsSource
+from biibaa.adapters.ecosyste_ms import EcosystemsSource
+from biibaa.ports.dependents import DependentsSource
+
+log = structlog.get_logger(__name__)
+
+_DEFAULT_CACHE_PATH = Path("data/dependents_cache.sqlite")
+
+
+def build_dependents_source(
+    *,
+    cache_path: Path = _DEFAULT_CACHE_PATH,
+    oso_api_key_env: str = "OSO_API_KEY",
+) -> DependentsSource:
+    fallback = EcosystemsSource()
+    api_key = os.environ.get(oso_api_key_env)
+    if not api_key:
+        log.info(
+            "dependents.factory", backend="ecosyste_ms_only", reason="no_oso_api_key"
+        )
+        return fallback
+
+    try:
+        from biibaa.adapters.pyoso_dependents import PyosoSource
+    except ImportError:
+        log.warning(
+            "dependents.factory",
+            backend="ecosyste_ms_only",
+            reason="pyoso_extra_missing",
+        )
+        return fallback
+
+    primary = PyosoSource(api_key=api_key)
+    cache = DependentsCache(path=cache_path)
+    log.info("dependents.factory", backend="tiered", primary="pyoso")
+    return TieredDependentsSource(cache=cache, primary=primary, fallback=fallback)

--- a/src/biibaa/adapters/dependents_tiered.py
+++ b/src/biibaa/adapters/dependents_tiered.py
@@ -1,0 +1,82 @@
+"""Tiered dependents source: cache → primary → fallback.
+
+Order of operations per `fetch_dependents` call:
+
+  1. Read the SQLite cache. Cache hit → return.
+  2. Call the primary source (deps.dev). Non-empty → cache + return.
+  3. Call the fallback source (ecosyste.ms). Non-empty → cache + return.
+  4. Return [] (and don't cache, so next run can retry).
+
+The cache key is (system, name, iso_week) so weekly biibaa runs naturally
+hit it. We don't cache empty results — an empty list is more likely "both
+backends were down" than "this package has zero dependents."
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from biibaa.adapters.dependents_cache import DependentsCache
+from biibaa.ports.dependents import Dependent, DependentsSource
+
+log = structlog.get_logger(__name__)
+
+
+class TieredDependentsSource:
+    name = "tiered_dependents"
+
+    def __init__(
+        self,
+        *,
+        cache: DependentsCache,
+        primary: DependentsSource | None,
+        fallback: DependentsSource,
+        system: str = "npm",
+    ) -> None:
+        self._cache = cache
+        self._primary = primary
+        self._fallback = fallback
+        self._system = system
+
+    def fetch_dependents(self, *, package: str, top_k: int = 10) -> list[Dependent]:
+        cached = self._cache.get(system=self._system, name=package)
+        if cached is not None:
+            log.info("dependents.cache_hit", package=package, count=len(cached))
+            return cached[:top_k]
+
+        if self._primary is not None:
+            primary_result = self._primary.fetch_dependents(
+                package=package, top_k=top_k
+            )
+            if primary_result:
+                log.info(
+                    "dependents.primary_hit",
+                    source=self._primary.name,
+                    package=package,
+                    count=len(primary_result),
+                )
+                self._cache.put(
+                    system=self._system, name=package, dependents=primary_result
+                )
+                return primary_result
+
+        fallback_result = self._fallback.fetch_dependents(
+            package=package, top_k=top_k
+        )
+        if fallback_result:
+            log.info(
+                "dependents.fallback_hit",
+                source=self._fallback.name,
+                package=package,
+                count=len(fallback_result),
+            )
+            self._cache.put(
+                system=self._system, name=package, dependents=fallback_result
+            )
+        return fallback_result
+
+    def close(self) -> None:
+        if self._primary is not None:
+            self._primary.close()
+        self._fallback.close()
+        self._cache.close()

--- a/src/biibaa/adapters/ecosyste_ms.py
+++ b/src/biibaa/adapters/ecosyste_ms.py
@@ -10,28 +10,24 @@ endpoint, with no auth required.
 
 Returns up to K dependents ranked by lifetime npm downloads, each with
 the repository_url we need to make a brief actionable.
+
+Wrapped with a circuit breaker because the highest-signal packages
+(lodash, debug, axios, ...) reliably 500 on this endpoint — without
+the breaker we hammer a known-broken host every run.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import httpx
 import structlog
 
+from biibaa.adapters._circuit import CircuitBreaker
 from biibaa.adapters._http import make_client
+from biibaa.ports.dependents import Dependent
 
 log = structlog.get_logger(__name__)
 
 ECOSYSTEMS_BASE = "https://packages.ecosyste.ms/api/v1/registries/npmjs.org/packages"
-
-
-@dataclass(frozen=True)
-class Dependent:
-    name: str
-    purl: str
-    repo_url: str | None
-    lifetime_downloads: int | None
 
 
 def _purl(name: str) -> str:
@@ -41,12 +37,28 @@ def _purl(name: str) -> str:
 class EcosystemsSource:
     name = "ecosyste_ms_dependents"
 
-    def __init__(self, *, client: httpx.Client | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        client: httpx.Client | None = None,
+        breaker: CircuitBreaker[list[Dependent]] | None = None,
+    ) -> None:
         # Tight timeout: many popular-package endpoints 500 instantly,
         # but a few hang with no response — don't let those starve the run.
         self._client = client or make_client(timeout=8.0)
+        self._breaker = breaker or CircuitBreaker[list[Dependent]](
+            name="ecosyste_ms",
+            failure_threshold=3,
+            reset_after_seconds=300.0,
+        )
 
     def fetch_dependents(self, *, package: str, top_k: int = 10) -> list[Dependent]:
+        return self._breaker.call(
+            lambda: self._fetch(package=package, top_k=top_k),
+            fallback=[],
+        )
+
+    def _fetch(self, *, package: str, top_k: int) -> list[Dependent]:
         url = f"{ECOSYSTEMS_BASE}/{package}/dependent_packages"
         params = {"sort": "downloads", "order": "desc", "per_page": top_k}
         try:

--- a/src/biibaa/adapters/github_repo.py
+++ b/src/biibaa/adapters/github_repo.py
@@ -1,13 +1,19 @@
 """GitHub repo activity adapter — fetches the most-recently-merged PR
-timestamp via the v4 GraphQL API. Used as a confidence signal for biibaa
-briefs: a repo whose maintainers merged something last week is far more
-likely to merge a drive-by contribution than one frozen for two years."""
+timestamp and the repo's archived flag via the v4 GraphQL API. Both signals
+are pulled in one query and cached together so `last_merged_pr_at` and
+`is_archived` callers share a single round-trip per repo.
+
+- `last_merged_pr_at` feeds the confidence axis (a repo whose maintainers
+  merged something last week is far more likely to merge a drive-by
+  contribution than one frozen for two years).
+- `is_archived` is a hard disqualifier — archived repos won't accept PRs."""
 
 from __future__ import annotations
 
 import os
 import re
 import subprocess
+from dataclasses import dataclass
 from datetime import datetime
 
 import httpx
@@ -20,14 +26,21 @@ log = structlog.get_logger(__name__)
 GRAPHQL_URL = "https://api.github.com/graphql"
 
 _QUERY = """
-query LastMergedPR($owner: String!, $name: String!) {
+query RepoMeta($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
+    isArchived
     pullRequests(states: MERGED, orderBy: {field: UPDATED_AT, direction: DESC}, first: 1) {
       nodes { mergedAt }
     }
   }
 }
 """
+
+
+@dataclass(frozen=True)
+class RepoMeta:
+    last_merged_pr_at: datetime | None
+    is_archived: bool
 
 _REPO_RE = re.compile(r"https?://github\.com/([^/]+)/([^/?#]+?)(?:\.git)?/?$")
 
@@ -65,7 +78,7 @@ class GithubRepoSource:
     ) -> None:
         self._token = _resolve_token(token)
         self._client = client or make_client(timeout=15.0)
-        self._cache: dict[tuple[str, str], datetime | None] = {}
+        self._cache: dict[tuple[str, str], RepoMeta | None] = {}
 
     def _headers(self) -> dict[str, str]:
         h = {"Accept": "application/vnd.github+json"}
@@ -73,7 +86,7 @@ class GithubRepoSource:
             h["Authorization"] = f"Bearer {self._token}"
         return h
 
-    def last_merged_pr_at(self, *, repo_url: str) -> datetime | None:
+    def fetch_meta(self, *, repo_url: str) -> RepoMeta | None:
         parsed = _parse_repo_url(repo_url)
         if not parsed:
             return None
@@ -100,18 +113,28 @@ class GithubRepoSource:
             self._cache[parsed] = None
             return None
 
-        nodes = (
-            ((payload.get("data") or {}).get("repository") or {})
-            .get("pullRequests", {})
-            .get("nodes")
-            or []
+        repo = ((payload.get("data") or {}).get("repository")) or {}
+        nodes = repo.get("pullRequests", {}).get("nodes") or []
+        merged_at: datetime | None = None
+        if nodes and nodes[0].get("mergedAt"):
+            merged_at = datetime.fromisoformat(
+                nodes[0]["mergedAt"].replace("Z", "+00:00")
+            )
+        meta = RepoMeta(
+            last_merged_pr_at=merged_at, is_archived=bool(repo.get("isArchived"))
         )
-        if not nodes or not nodes[0].get("mergedAt"):
-            self._cache[parsed] = None
-            return None
-        merged_at = datetime.fromisoformat(nodes[0]["mergedAt"].replace("Z", "+00:00"))
-        self._cache[parsed] = merged_at
-        return merged_at
+        self._cache[parsed] = meta
+        return meta
+
+    def last_merged_pr_at(self, *, repo_url: str) -> datetime | None:
+        meta = self.fetch_meta(repo_url=repo_url)
+        return meta.last_merged_pr_at if meta else None
+
+    def is_archived(self, *, repo_url: str) -> bool:
+        meta = self.fetch_meta(repo_url=repo_url)
+        # Unknown / unreachable repos are NOT treated as archived — better to
+        # over-include than silently drop a project on a transient API blip.
+        return bool(meta and meta.is_archived)
 
     def close(self) -> None:
         self._client.close()

--- a/src/biibaa/adapters/pyoso_dependents.py
+++ b/src/biibaa/adapters/pyoso_dependents.py
@@ -1,0 +1,118 @@
+"""Pyoso (Open Source Observer) dependents adapter.
+
+Joins `sboms_v0` (the dependents-fan-out edge list) with `repositories_v0`
+to rank by GitHub star count. Returns GitHub repos directly — which is more
+useful than npm package names for biibaa's "where do I PR" question.
+
+The `pyoso` library is optional — installed via the `[pyoso]` extra.
+Auth is via the OSO_API_KEY env var (or explicit api_key= to the Client).
+
+We sanitize the package name with a strict regex before splicing into SQL
+because pyoso's `to_pandas` takes raw SQL with no parameterization.
+"""
+
+from __future__ import annotations
+
+import re
+
+import structlog
+
+from biibaa.adapters._circuit import CircuitBreaker
+from biibaa.ports.dependents import Dependent
+
+log = structlog.get_logger(__name__)
+
+try:
+    from pyoso import Client  # type: ignore[import-not-found]
+except ImportError as e:  # pragma: no cover - exercised only when extra missing
+    raise ImportError(
+        "pyoso adapter requires the 'pyoso' extra: pip install 'biibaa[pyoso]'"
+    ) from e
+
+
+# npm package name spec: lowercase, digits, dot, hyphen, underscore, optional
+# scoped form `@scope/name`. Reject anything else to keep raw-SQL splicing safe.
+_NPM_NAME_RE = re.compile(r"^(@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$")
+
+_QUERY_TEMPLATE = """
+SELECT
+  s.dependent_artifact_namespace AS owner,
+  s.dependent_artifact_name AS repo,
+  r.star_count AS star_count,
+  r.artifact_url AS repo_url
+FROM sboms_v0 s
+LEFT JOIN repositories_v0 r
+  ON s.dependent_artifact_id = r.artifact_id
+WHERE s.package_artifact_source = 'NPM'
+  AND s.package_artifact_name = '{package}'
+  AND s.dependent_artifact_source = 'GITHUB'
+  AND r.star_count >= {min_stars}
+ORDER BY r.star_count DESC NULLS LAST
+LIMIT {top_k}
+"""
+
+
+class PyosoSource:
+    """Dependents source backed by OSO's sboms_v0 mart."""
+
+    name = "pyoso_dependents"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        client: Client | None = None,
+        min_stars: int = 10,
+        breaker: CircuitBreaker[list[Dependent]] | None = None,
+    ) -> None:
+        self._client = client or Client(api_key=api_key)
+        self._min_stars = min_stars
+        self._breaker = breaker or CircuitBreaker[list[Dependent]](
+            name="pyoso",
+            failure_threshold=3,
+            reset_after_seconds=300.0,
+        )
+
+    def fetch_dependents(self, *, package: str, top_k: int = 10) -> list[Dependent]:
+        if not _NPM_NAME_RE.match(package):
+            log.warning("pyoso.invalid_package_name", package=package)
+            return []
+        return self._breaker.call(
+            lambda: self._fetch(package=package, top_k=top_k),
+            fallback=[],
+        )
+
+    def _fetch(self, *, package: str, top_k: int) -> list[Dependent]:
+        sql = _QUERY_TEMPLATE.format(
+            package=package, min_stars=self._min_stars, top_k=top_k
+        )
+        try:
+            df = self._client.to_pandas(sql)
+        except Exception as e:
+            log.warning("pyoso.query_error", package=package, error=str(e))
+            return []
+        out: list[Dependent] = []
+        for row in df.itertuples(index=False):
+            owner = row.owner
+            repo = row.repo
+            if not owner or not repo:
+                continue
+            full = f"{owner}/{repo}"
+            out.append(
+                Dependent(
+                    name=full,
+                    purl=f"pkg:github/{full}",
+                    repo_url=row.repo_url or f"https://github.com/{full}",
+                    lifetime_downloads=None,
+                )
+            )
+        return out
+
+    def close(self) -> None:
+        # pyoso Client has no explicit close.
+        pass
+
+
+def build_query(*, package: str, min_stars: int, top_k: int) -> str:
+    """Exposed for tests + dry-run inspection."""
+    return _QUERY_TEMPLATE.format(package=package, min_stars=min_stars, top_k=top_k)

--- a/src/biibaa/pipeline/run.py
+++ b/src/biibaa/pipeline/run.py
@@ -20,13 +20,14 @@ from pathlib import Path
 
 import structlog
 
+from biibaa.adapters.dependents_factory import build_dependents_source
 from biibaa.adapters.e18e import E18eReplacementsSource
-from biibaa.adapters.ecosyste_ms import Dependent, EcosystemsSource
 from biibaa.adapters.github_advisories import GithubAdvisorySource
 from biibaa.adapters.github_repo import GithubRepoSource
 from biibaa.adapters.npm_downloads import NpmDownloadsSource
 from biibaa.briefs.render import write_brief
 from biibaa.domain import Advisory, Brief, Opportunity, Project, Replacement
+from biibaa.ports.dependents import Dependent, DependentsSource
 from biibaa.scoring import (
     REPLACEMENT_EFFORT_SCORE,
     confidence,
@@ -50,7 +51,10 @@ class _ProjectFindings:
 
 
 def _project_name_from_purl(purl: str) -> str:
-    return purl.removeprefix("pkg:npm/")
+    # Pyoso dependents arrive as `pkg:github/owner/repo`; ecosyste.ms as
+    # `pkg:npm/name`. Strip whichever prefix matches so slugs and download
+    # lookups use the canonical short form.
+    return purl.removeprefix("pkg:npm/").removeprefix("pkg:github/")
 
 
 def _project_from(
@@ -60,6 +64,7 @@ def _project_from(
     repo_url: str | None,
     *,
     last_pr_merged_at: datetime | None = None,
+    archived: bool = False,
 ) -> Project:
     return Project(
         purl=purl,
@@ -68,6 +73,21 @@ def _project_from(
         downloads_weekly=downloads,
         repo_url=repo_url,
         last_pr_merged_at=last_pr_merged_at,
+        archived=archived,
+    )
+
+
+def _is_eligible(project: Project, *, min_weekly_downloads: int) -> bool:
+    """Drop archived repos and packages below the weekly-downloads floor.
+
+    Unknown downloads (None) pass through — better to over-include than to
+    silently drop a project on a transient npm registry hiccup.
+    """
+    if project.archived:
+        return False
+    return not (
+        project.downloads_weekly is not None
+        and project.downloads_weekly < min_weekly_downloads
     )
 
 
@@ -165,7 +185,7 @@ def _select_with_axis_quota(
 def _fan_out_dependents(
     *,
     replacements: list[Replacement],
-    eco_src: EcosystemsSource,
+    eco_src: DependentsSource,
     downloads_src: NpmDownloadsSource,
     fanout_top_n: int,
     dependents_per_replacement: int,
@@ -207,6 +227,7 @@ def run(
     max_opps_per_project: int = 6,
     fanout_top_n: int = 40,
     dependents_per_replacement: int = 5,
+    min_weekly_downloads: int = 50_000,
 ) -> list[Path]:
     """Pull advisories + replacement-fan-outs, score, render top-N briefs."""
     run_at = datetime.now(UTC)
@@ -215,7 +236,9 @@ def run(
     advisory_src = GithubAdvisorySource()
     downloads_src = NpmDownloadsSource()
     e18e_src = E18eReplacementsSource() if include_replacements else None
-    eco_src = EcosystemsSource() if include_replacements else None
+    eco_src: DependentsSource | None = (
+        build_dependents_source() if include_replacements else None
+    )
     repo_src = GithubRepoSource()
 
     advisories: list[Advisory] = list(
@@ -260,8 +283,8 @@ def run(
     projects: dict[str, Project] = {}
     for purl, findings in by_project.items():
         name = _project_name_from_purl(purl)
-        last_pr = (
-            repo_src.last_merged_pr_at(repo_url=findings.repo_url)
+        meta = (
+            repo_src.fetch_meta(repo_url=findings.repo_url)
             if findings.repo_url
             else None
         )
@@ -270,13 +293,28 @@ def run(
             ecosystem,
             bulk_downloads.get(name),
             findings.repo_url,
-            last_pr_merged_at=last_pr,
+            last_pr_merged_at=meta.last_merged_pr_at if meta else None,
+            archived=meta.is_archived if meta else False,
         )
+
+    skipped = sum(
+        1
+        for p in projects.values()
+        if not _is_eligible(p, min_weekly_downloads=min_weekly_downloads)
+    )
+    log.info(
+        "pipeline.eligibility_filter",
+        kept=len(projects) - skipped,
+        skipped=skipped,
+        min_weekly_downloads=min_weekly_downloads,
+    )
 
     # Build opportunities + briefs.
     briefs: list[Brief] = []
     for purl, findings in by_project.items():
         project = projects[purl]
+        if not _is_eligible(project, min_weekly_downloads=min_weekly_downloads):
+            continue
         opps: list[Opportunity] = []
         for adv in _dedupe_advisories(findings.advisories):
             opps.append(_vuln_opportunity(advisory=adv, project=project, run_at=run_at))

--- a/src/biibaa/ports/dependents.py
+++ b/src/biibaa/ports/dependents.py
@@ -1,0 +1,27 @@
+"""DependentsSource port — fan-out from a package to its top dependents.
+
+Implementations live in `biibaa.adapters` (ecosyste.ms, deps.dev BigQuery,
+SQLite cache, tiered composite). Pipeline depends only on this protocol so
+backends can be swapped per-deployment without touching scoring or rendering.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class Dependent:
+    name: str
+    purl: str
+    repo_url: str | None
+    lifetime_downloads: int | None
+
+
+class DependentsSource(Protocol):
+    name: str
+
+    def fetch_dependents(self, *, package: str, top_k: int = 10) -> list[Dependent]: ...
+
+    def close(self) -> None: ...

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,59 @@
+"""CircuitBreaker contract tests."""
+
+from __future__ import annotations
+
+from biibaa.adapters._circuit import CircuitBreaker
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def test_opens_after_consecutive_failures() -> None:
+    clock = _Clock()
+    cb = CircuitBreaker[list[int]](
+        name="t", failure_threshold=2, reset_after_seconds=10, clock=clock
+    )
+    assert cb.call(lambda: [], fallback=[]) == []  # 1st empty -> failure
+    assert cb.call(lambda: [], fallback=[]) == []  # 2nd empty -> opens
+    assert cb.is_open is True
+
+    calls = {"n": 0}
+
+    def underlying() -> list[int]:
+        calls["n"] += 1
+        return [1, 2, 3]
+
+    # Open: underlying must NOT be called.
+    assert cb.call(underlying, fallback=[]) == []
+    assert calls["n"] == 0
+
+
+def test_half_open_then_close_on_success() -> None:
+    clock = _Clock()
+    cb = CircuitBreaker[list[int]](
+        name="t", failure_threshold=1, reset_after_seconds=10, clock=clock
+    )
+    cb.call(lambda: [], fallback=[])  # opens
+    assert cb.is_open is True
+
+    clock.t = 11  # past reset window
+    assert cb.is_open is False
+    assert cb.call(lambda: [42], fallback=[]) == [42]
+    # Subsequent failure should not immediately re-open (threshold=1, but
+    # state was reset on success).
+    assert cb.is_open is False
+
+
+def test_exception_counts_as_failure() -> None:
+    cb = CircuitBreaker[list[int]](name="t", failure_threshold=1)
+
+    def boom() -> list[int]:
+        raise RuntimeError("nope")
+
+    assert cb.call(boom, fallback=[99]) == [99]
+    assert cb.is_open is True

--- a/tests/test_dependents_cache.py
+++ b/tests/test_dependents_cache.py
@@ -1,0 +1,56 @@
+"""DependentsCache contract tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from biibaa.adapters.dependents_cache import DependentsCache
+from biibaa.ports.dependents import Dependent
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 26, tzinfo=UTC)
+
+
+def test_round_trip(tmp_path: Path) -> None:
+    cache = DependentsCache(path=tmp_path / "c.sqlite", clock=_now)
+    deps = [
+        Dependent(name="a", purl="pkg:npm/a", repo_url="https://x/a", lifetime_downloads=1),
+        Dependent(name="b", purl="pkg:npm/b", repo_url=None, lifetime_downloads=None),
+    ]
+    cache.put(system="npm", name="lodash", dependents=deps)
+    got = cache.get(system="npm", name="lodash")
+    assert got == deps
+
+
+def test_miss_returns_none(tmp_path: Path) -> None:
+    cache = DependentsCache(path=tmp_path / "c.sqlite", clock=_now)
+    assert cache.get(system="npm", name="never-cached") is None
+
+
+def test_unopenable_path_degrades_to_no_op(tmp_path: Path) -> None:
+    """Disk full / unwritable path: cache must not crash the pipeline."""
+    bad = tmp_path / "does" / "not" / "exist"
+    bad.parent.mkdir(parents=True)
+    bad.parent.chmod(0o400)  # parent dir read-only -> sqlite open fails
+    try:
+        cache = DependentsCache(path=bad / "c.sqlite", clock=_now)
+        assert cache.get(system="npm", name="x") is None
+        dep = Dependent(name="a", purl="p", repo_url=None, lifetime_downloads=None)
+        cache.put(system="npm", name="x", dependents=[dep])
+        assert cache.get(system="npm", name="x") is None  # no-op
+        cache.close()
+    finally:
+        bad.parent.chmod(0o700)
+
+
+def test_different_week_is_a_miss(tmp_path: Path) -> None:
+    t = {"now": datetime(2026, 4, 26, tzinfo=UTC)}
+    cache = DependentsCache(path=tmp_path / "c.sqlite", clock=lambda: t["now"])
+    cache.put(system="npm", name="x", dependents=[])
+    # Same week -> hit (empty list, but not None)
+    assert cache.get(system="npm", name="x") == []
+    # Jump weeks
+    t["now"] = datetime(2026, 5, 12, tzinfo=UTC)
+    assert cache.get(system="npm", name="x") is None

--- a/tests/test_dependents_tiered.py
+++ b/tests/test_dependents_tiered.py
@@ -1,0 +1,90 @@
+"""TieredDependentsSource fallback ordering."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from biibaa.adapters.dependents_cache import DependentsCache
+from biibaa.adapters.dependents_tiered import TieredDependentsSource
+from biibaa.ports.dependents import Dependent
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 26, tzinfo=UTC)
+
+
+class _Stub:
+    def __init__(self, name: str, result: list[Dependent]) -> None:
+        self.name = name
+        self.result = result
+        self.calls = 0
+
+    def fetch_dependents(self, *, package: str, top_k: int = 10) -> list[Dependent]:
+        self.calls += 1
+        return self.result
+
+    def close(self) -> None:
+        pass
+
+
+def _dep(name: str) -> Dependent:
+    return Dependent(name=name, purl=f"pkg:npm/{name}", repo_url=None, lifetime_downloads=None)
+
+
+def test_primary_hit_skips_fallback(tmp_path: Path) -> None:
+    cache = DependentsCache(path=tmp_path / "c.sqlite", clock=_now)
+    primary = _Stub("primary", [_dep("a")])
+    fallback = _Stub("fallback", [_dep("b")])
+    src = TieredDependentsSource(cache=cache, primary=primary, fallback=fallback)
+
+    out = src.fetch_dependents(package="lodash", top_k=5)
+    assert [d.name for d in out] == ["a"]
+    assert primary.calls == 1
+    assert fallback.calls == 0
+
+
+def test_primary_empty_falls_back(tmp_path: Path) -> None:
+    cache = DependentsCache(path=tmp_path / "c.sqlite", clock=_now)
+    primary = _Stub("primary", [])
+    fallback = _Stub("fallback", [_dep("b")])
+    src = TieredDependentsSource(cache=cache, primary=primary, fallback=fallback)
+
+    out = src.fetch_dependents(package="lodash", top_k=5)
+    assert [d.name for d in out] == ["b"]
+    assert primary.calls == 1
+    assert fallback.calls == 1
+
+
+def test_cache_hit_skips_both(tmp_path: Path) -> None:
+    cache = DependentsCache(path=tmp_path / "c.sqlite", clock=_now)
+    cache.put(system="npm", name="lodash", dependents=[_dep("cached")])
+    primary = _Stub("primary", [_dep("a")])
+    fallback = _Stub("fallback", [_dep("b")])
+    src = TieredDependentsSource(cache=cache, primary=primary, fallback=fallback)
+
+    out = src.fetch_dependents(package="lodash", top_k=5)
+    assert [d.name for d in out] == ["cached"]
+    assert primary.calls == 0
+    assert fallback.calls == 0
+
+
+def test_no_primary_uses_fallback_directly(tmp_path: Path) -> None:
+    cache = DependentsCache(path=tmp_path / "c.sqlite", clock=_now)
+    fallback = _Stub("fallback", [_dep("b")])
+    src = TieredDependentsSource(cache=cache, primary=None, fallback=fallback)
+
+    out = src.fetch_dependents(package="lodash", top_k=5)
+    assert [d.name for d in out] == ["b"]
+    assert fallback.calls == 1
+
+
+def test_empty_results_are_not_cached(tmp_path: Path) -> None:
+    cache = DependentsCache(path=tmp_path / "c.sqlite", clock=_now)
+    primary = _Stub("primary", [])
+    fallback = _Stub("fallback", [])
+    src = TieredDependentsSource(cache=cache, primary=primary, fallback=fallback)
+
+    src.fetch_dependents(package="lodash", top_k=5)
+    # If empty had been cached we'd see a hit (empty list), not None.
+    assert cache.get(system="npm", name="lodash") is None

--- a/tests/test_github_repo.py
+++ b/tests/test_github_repo.py
@@ -81,3 +81,51 @@ def test_unparseable_repo_url_returns_none() -> None:
     src = GithubRepoSource(token="x", client=httpx.Client())
     assert src.last_merged_pr_at(repo_url="not-a-url") is None
     assert src.last_merged_pr_at(repo_url="https://gitlab.com/x/y") is None
+
+
+def test_is_archived_true(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        method="POST",
+        json={
+            "data": {
+                "repository": {
+                    "isArchived": True,
+                    "pullRequests": {"nodes": []},
+                }
+            }
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    assert src.is_archived(repo_url="https://github.com/old/lib") is True
+
+
+def test_is_archived_false_on_unreachable_repo(httpx_mock: HTTPXMock) -> None:
+    """Transient failures must NOT spuriously mark a repo as archived."""
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql", method="POST", status_code=502
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    assert src.is_archived(repo_url="https://github.com/example/repo") is False
+
+
+def test_fetch_meta_shares_cache_across_methods(httpx_mock: HTTPXMock) -> None:
+    """One HTTP call should serve both is_archived and last_merged_pr_at."""
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        method="POST",
+        json={
+            "data": {
+                "repository": {
+                    "isArchived": False,
+                    "pullRequests": {
+                        "nodes": [{"mergedAt": "2026-04-01T00:00:00Z"}]
+                    },
+                }
+            }
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    src.is_archived(repo_url="https://github.com/foo/bar")
+    src.last_merged_pr_at(repo_url="https://github.com/foo/bar")
+    # No second mock registered — pytest-httpx fails teardown if a 2nd call fired.

--- a/tests/test_pipeline_filter.py
+++ b/tests/test_pipeline_filter.py
@@ -1,0 +1,39 @@
+"""Eligibility filter — drop archived repos and packages below downloads floor."""
+
+from __future__ import annotations
+
+from biibaa.domain import Project
+from biibaa.pipeline.run import _is_eligible
+
+
+def _project(*, archived: bool = False, downloads: int | None = 100_000) -> Project:
+    return Project(
+        purl="pkg:npm/x",
+        ecosystem="npm",
+        name="x",
+        archived=archived,
+        downloads_weekly=downloads,
+    )
+
+
+def test_eligible_when_active_and_popular() -> None:
+    assert _is_eligible(_project(), min_weekly_downloads=50_000) is True
+
+
+def test_filtered_when_archived() -> None:
+    assert _is_eligible(_project(archived=True), min_weekly_downloads=50_000) is False
+
+
+def test_filtered_when_below_downloads_floor() -> None:
+    assert (
+        _is_eligible(_project(downloads=49_999), min_weekly_downloads=50_000) is False
+    )
+
+
+def test_unknown_downloads_passes() -> None:
+    """A None downloads count means npm-stat blip — don't drop the project."""
+    assert _is_eligible(_project(downloads=None), min_weekly_downloads=50_000) is True
+
+
+def test_at_threshold_is_eligible() -> None:
+    assert _is_eligible(_project(downloads=50_000), min_weekly_downloads=50_000) is True

--- a/tests/test_pyoso_dependents.py
+++ b/tests/test_pyoso_dependents.py
@@ -1,0 +1,99 @@
+"""PyosoSource contract — sboms_v0 + repositories_v0 join.
+
+Skipped if the optional [pyoso] extra isn't installed."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pyoso")
+
+import pandas as pd  # noqa: E402
+
+from biibaa.adapters.pyoso_dependents import (  # noqa: E402
+    PyosoSource,
+    build_query,
+)
+from biibaa.ports.dependents import Dependent  # noqa: E402
+
+
+def test_query_filters_npm_github_with_min_stars() -> None:
+    q = build_query(package="debug", min_stars=100, top_k=20)
+    assert "package_artifact_source = 'NPM'" in q
+    assert "package_artifact_name = 'debug'" in q
+    assert "dependent_artifact_source = 'GITHUB'" in q
+    assert "star_count >= 100" in q
+    assert "ORDER BY r.star_count DESC" in q
+    assert "LIMIT 20" in q
+
+
+def test_query_joins_sboms_with_repositories() -> None:
+    q = build_query(package="lodash", min_stars=10, top_k=5)
+    assert "FROM sboms_v0 s" in q
+    assert "LEFT JOIN repositories_v0 r" in q
+    assert "ON s.dependent_artifact_id = r.artifact_id" in q
+
+
+class _StubClient:
+    def __init__(self, df: pd.DataFrame) -> None:
+        self.df = df
+        self.last_sql: str | None = None
+
+    def to_pandas(self, sql: str) -> pd.DataFrame:
+        self.last_sql = sql
+        return self.df
+
+
+def test_maps_rows_to_github_dependents() -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "owner": "facebook",
+                "repo": "react",
+                "star_count": 244574,
+                "repo_url": "https://github.com/facebook/react",
+            },
+            {
+                "owner": "vuejs",
+                "repo": "vue",
+                "star_count": 209840,
+                "repo_url": "https://github.com/vuejs/vue",
+            },
+        ]
+    )
+    src = PyosoSource(client=_StubClient(df))
+    out = src.fetch_dependents(package="debug", top_k=10)
+    assert out == [
+        Dependent(
+            name="facebook/react",
+            purl="pkg:github/facebook/react",
+            repo_url="https://github.com/facebook/react",
+            lifetime_downloads=None,
+        ),
+        Dependent(
+            name="vuejs/vue",
+            purl="pkg:github/vuejs/vue",
+            repo_url="https://github.com/vuejs/vue",
+            lifetime_downloads=None,
+        ),
+    ]
+
+
+def test_rejects_invalid_package_name() -> None:
+    """Defends raw-SQL splicing — non-npm-spec names are dropped, not run."""
+    src = PyosoSource(client=_StubClient(pd.DataFrame()))
+    assert src.fetch_dependents(package="debug'; DROP TABLE x;--", top_k=10) == []
+    assert src.fetch_dependents(package="@scope/pkg", top_k=10) == []  # this IS valid
+    # Verify no SQL fired for the bad name
+    bad = PyosoSource(client=_StubClient(pd.DataFrame()))
+    bad.fetch_dependents(package="../etc/passwd", top_k=10)
+    assert bad._client.last_sql is None  # type: ignore[attr-defined]
+
+
+def test_query_error_returns_empty() -> None:
+    class _Boom:
+        def to_pandas(self, sql: str) -> pd.DataFrame:
+            raise RuntimeError("500 Internal Server Error")
+
+    src = PyosoSource(client=_Boom())
+    assert src.fetch_dependents(package="debug", top_k=10) == []

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,18 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -49,6 +59,11 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+pyoso = [
+    { name = "pyoso" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
@@ -62,9 +77,11 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.7" },
+    { name = "pyoso", marker = "extra == 'pyoso'", specifier = ">=0.9" },
     { name = "structlog", specifier = ">=24.1" },
     { name = "typer", specifier = ">=0.12" },
 ]
+provides-extras = ["pyoso"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -81,6 +98,79 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -368,12 +458,125 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/b0/c20bd4d6d3f736e6bd6b55794e9cd0a617b858eaad27c8f410ea05d953b7/pandas-3.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:232a70ebb568c0c4d2db4584f338c1577d81e3af63292208d615907b698a0f18", size = 10347921, upload-time = "2026-03-31T06:46:33.36Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d0/4831af68ce30cc2d03c697bea8450e3225a835ef497d0d70f31b8cdde965/pandas-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:970762605cff1ca0d3f71ed4f3a769ea8f85fc8e6348f6e110b8fea7e6eb5a14", size = 9888127, upload-time = "2026-03-31T06:46:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a9/16ea9346e1fc4a96e2896242d9bc674764fb9049b0044c0132502f7a771e/pandas-3.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aff4e6f4d722e0652707d7bcb190c445fe58428500c6d16005b02401764b1b3d", size = 10399577, upload-time = "2026-03-31T06:46:39.224Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a8/3a61a721472959ab0ce865ef05d10b0d6bfe27ce8801c99f33d4fa996e65/pandas-3.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef8b27695c3d3dc78403c9a7d5e59a62d5464a7e1123b4e0042763f7104dc74f", size = 10880030, upload-time = "2026-03-31T06:46:42.412Z" },
+    { url = "https://files.pythonhosted.org/packages/da/65/7225c0ea4d6ce9cb2160a7fb7f39804871049f016e74782e5dade4d14109/pandas-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f8d68083e49e16b84734eb1a4dcae4259a75c90fb6e2251ab9a00b61120c06ab", size = 11409468, upload-time = "2026-03-31T06:46:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/46e7c76032639f2132359b5cf4c785dd8cf9aea5ea64699eac752f02b9db/pandas-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32cc41f310ebd4a296d93515fcac312216adfedb1894e879303987b8f1e2b97d", size = 11936381, upload-time = "2026-03-31T06:46:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/8b/721a9cff6fa6a91b162eb51019c6243b82b3226c71bb6c8ef4a9bd65cbc6/pandas-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:a4785e1d6547d8427c5208b748ae2efb64659a21bd82bf440d4262d02bfa02a4", size = 9744993, upload-time = "2026-03-31T06:46:51.488Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/18/7f0bd34ae27b28159aa80f2a6799f47fda34f7fb938a76e20c7b7fe3b200/pandas-3.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:08504503f7101300107ecdc8df73658e4347586db5cfdadabc1592e9d7e7a0fd", size = 9056118, upload-time = "2026-03-31T06:46:54.548Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
+    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
+    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
+    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
 ]
 
 [[package]]
@@ -494,6 +697,21 @@ wheels = [
 ]
 
 [[package]]
+name = "pyoso"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pandas" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sqlglot" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/81/29c21ddf052dfd0895ac2d30f2dde63e0f6f0e7a41dd01bbb0a1c71322e0/pyoso-0.9.0.tar.gz", hash = "sha256:466ce360f924a5b67673409dc8c5574f4a7840a30438ee9fb54aa49896fbe266", size = 10195, upload-time = "2026-04-20T23:42:55.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/97/884a88485fa24e27ece034fbc3363a88607ca71bdba1de328079b5ece981/pyoso-0.9.0-py3-none-any.whl", hash = "sha256:6d24a46ac05086aa3e05677fc7ab1e873c194b462469af494210e342220026b2", size = 9189, upload-time = "2026-04-20T23:42:53.975Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -520,6 +738,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4e/42/f53c58570e80d503ade9dd42ce57f2915d14bcbe25f6308138143950d1d6/pytest_httpx-0.36.2.tar.gz", hash = "sha256:05a56527484f7f4e8c856419ea379b8dc359c36801c4992fdb330f294c690356", size = 57683, upload-time = "2026-04-09T13:57:19.837Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/55/1fa65f8e4fceb19dd6daa867c162ad845d547f6058cd92b4b02384a44777/pytest_httpx-0.36.2-py3-none-any.whl", hash = "sha256:d42ebd5679442dc7bfb0c48e0767b6562e9bc4534d805127b0084171886a5e22", size = 20315, upload-time = "2026-04-09T13:57:18.587Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -570,6 +815,24 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sqlglot"
+version = "30.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/66/6ece15f197874e56c76e1d0269cebf284ba992a80dfadca9d1972fdf7edf/sqlglot-30.6.0.tar.gz", hash = "sha256:246d34d39927422a50a3fa155f37b2f6346fba85f1a755b13c941eb32ef93361", size = 5835307, upload-time = "2026-04-20T20:11:08.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/e7/64fe971cbca33a0446b06f4a5ff8e3fa4a1dbd0a039ceabcc3e6cf4087a9/sqlglot-30.6.0-py3-none-any.whl", hash = "sha256:e005fc2f47994f90d7d8df341f1cbe937518497b0b7b1507d4c03c4c9dfd2778", size = 673920, upload-time = "2026-04-20T20:11:05.758Z" },
+]
+
+[[package]]
 name = "structlog"
 version = "25.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -612,4 +875,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]


### PR DESCRIPTION
## Summary

Replaces the silently-empty ecosyste.ms-only fan-out with a tiered `DependentsSource`: weekly SQLite cache → **pyoso** (OSO `sboms_v0` ⨝ `repositories_v0` ranked by GitHub stars) → ecosyste.ms with a circuit breaker.

Hot packages like `lodash`/`debug`/`axios` — which reliably 500 on ecosyste.ms — now return real high-star repos (`react`, `vue`, `vscode`, `next.js`, `electron`, `node`, ...). On a real run this turned replacement-led briefs from **0** into **9 of 15** total.

Also adds an eligibility filter that drops projects whose GitHub repo is archived or whose weekly downloads are below 50 k.

## How it works

- **`ports/dependents.py`** — `DependentsSource` Protocol; backends swap per-deployment via the factory.
- **`adapters/pyoso_dependents.py`** — joins `sboms_v0` (the dependents fan-out edge list) with `repositories_v0` for star ranking. Returns GitHub repos directly (right thing to PR against). Strict regex on the package name guards raw-SQL splicing since pyoso has no parameterization.
- **`adapters/ecosyste_ms.py`** — wrapped with the new `CircuitBreaker` (3 consecutive failures → 5 min cool-down). Existing contract preserved.
- **`adapters/_circuit.py`** — generic, treats empty-list results as failures so a 500-returning-200 endpoint can still trip the breaker.
- **`adapters/dependents_cache.py`** — SQLite, keyed by `(system, name, iso_week)`. Every operation swallows `OSError`/`sqlite3.Error` and logs — disk-full or read-only-path no longer crashes the pipeline.
- **`adapters/dependents_tiered.py`** — cache → primary → fallback; empty results are NOT cached so the next run can retry.
- **`adapters/dependents_factory.py`** — picks tiered (pyoso primary) when `OSO_API_KEY` is set, plain ecosyste.ms otherwise.
- **`pipeline/run.py`** — `_is_eligible(project, min_weekly_downloads)` filter + `min_weekly_downloads: int = 50_000` `run()` arg. Unknown downloads (`None`) pass through to avoid dropping projects on transient npm-stat blips.
- **`adapters/github_repo.py`** — single GraphQL query now returns both `mergedAt` and `isArchived`; `is_archived(repo_url)` and `last_merged_pr_at(repo_url)` share one cache. Transient API failures do NOT mark a repo archived.

## What we ruled out, and why

- **deps.dev BigQuery `Dependents`** — `bigquery-public-data.deps_dev_v1.Dependents` is partitioned by `SnapshotAt` but **not clustered** (the docs and the table's own `OPTIONS(description=...)` lie about this; the actual `CREATE TABLE` DDL has no `CLUSTER BY` clause). Single-package queries scan ~519 GB / **$2.59 each**, so 40 seeds = ~$104/run. Only economically viable with a weekly materialize step into a derived dataset, deferred to a separate PR.
- **deps.dev REST `GetDependencies`** — wrong direction (returns what package X imports, not who imports X). No `GetDependents` endpoint exists.

## Test plan

- [x] `uv run --native-tls pytest` — **51 passed** (12 new tests across `_circuit`, `dependents_cache`, `dependents_tiered`, `pipeline_filter`, `github_repo`, `pyoso_dependents`)
- [x] `uv run --native-tls ruff check src tests` — clean
- [x] End-to-end pipeline run with `OSO_API_KEY` set:
  - 21 advisories + 658 replacements → **40 fan-out seeds → 200 dependent edges → 15 briefs (6 vuln + 9 replacement)**
  - Eligibility filter: kept 15, skipped 11 (archived or <50 k downloads)
  - Sample dependents surfaced: `facebook/react`, `vuejs/vue`, `microsoft/vscode`, `vercel/next.js`, `electron/electron`, `nodejs/node`, `rust-lang/rust`, `langgenius/dify`
- [x] Cache resilience verified end-to-end after a real disk-full incident (`OSError(28)`); pipeline continues with cache no-op'd

## Operator notes

- `OSO_API_KEY` env var is required to enable the pyoso primary; without it the pipeline keeps working on ecosyste.ms-only with the circuit breaker.
- Cache lives at `data/dependents_cache.sqlite` (gitignored).
- pyoso queries are ~6–8 s each; 40 seeds takes ~6 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
