### PR TITLE
refactor(briefs): group brief output by package instead of run date

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ uv sync
 uv run biibaa run --top 20
 ```
 
-Briefs land in `data/briefs/<yyyy-mm-dd>/<project>.md`.
+Briefs land in `data/briefs/<project>/<yyyy-mm-dd>.md`.
 A pinned snapshot lives in [examples/briefs/](examples/briefs/).
 
 ## What you'll see

--- a/SPEC.md
+++ b/SPEC.md
@@ -105,7 +105,7 @@ sources → ingest (raw landing) → normalize (canonical model) → score → b
 2. **Normalize** — SQLMesh staging models read raw Parquet via DuckDB's `read_parquet`, decode into typed staging tables; intermediate models apply source precedence (§3.2) and dedupe. Time-partitioned raw inputs map to `INCREMENTAL_BY_TIME_RANGE` models keyed on the ingest date.
 3. **Fan-out** — for each flagged package, enumerate top-K dependents via npm browse (and ecosyste.ms when extending) to expand the candidate set.
 4. **Score** — apply heuristics (§6). Materialize `opportunities` table.
-5. **Brief** — pick top-N projects by aggregate score; render Markdown briefs to `data/briefs/<yyyy-mm-dd>/`.
+5. **Brief** — pick top-N projects by aggregate score; render Markdown briefs to `data/briefs/<project>/<yyyy-mm-dd>.md`.
 
 Each step is idempotent and replayable from raw.
 
@@ -207,7 +207,7 @@ data/
     replacements-fyi/2026-04-26/*.parquet
     npm-depended/<pkg>/2026-04-26.json
   warehouse.duckdb                  # canonical tables + views
-  briefs/2026-04-26/<project>.md
+  briefs/<project>/2026-04-26.md
 ```
 
 ### 8.1 Core tables
@@ -245,7 +245,7 @@ This is a deliberate departure from the TypeScript/Effect-TS preference in `arch
 | **Marts** | SQLMesh `FULL` or `INCREMENTAL` models | `projects`, `advisories`, `replacements`, `dependents`, `opportunities` |
 | **Score** | SQLMesh SQL + macros | Apply popularity + severity + effort heuristics; materialize `opportunities` |
 | **Audits** | SQLMesh audits | `not_null`, `unique_values`, `relationships`, custom (e.g. `score_in_range`) |
-| **Brief** | Python + Jinja2 | Read `opportunities` from DuckDB; render Markdown to `data/briefs/<date>/` |
+| **Brief** | Python + Jinja2 | Read `opportunities` from DuckDB; render Markdown to `data/briefs/<project>/<date>.md` |
 | **CLI** | Python (Typer) | `biibaa ingest <source>`, `biibaa run`, `biibaa brief`, `biibaa show <project>` |
 
 ### 9.2 Hexagonal split (Python)

--- a/src/biibaa/briefs/render.py
+++ b/src/biibaa/briefs/render.py
@@ -44,6 +44,6 @@ def render_brief(brief: Brief) -> str:
 
 def write_brief(brief: Brief, out_dir: Path) -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
-    path = out_dir / f"{brief.slug}.md"
+    path = out_dir / f"{brief.run_at.strftime('%Y-%m-%d')}.md"
     path.write_text(render_brief(brief))
     return path

--- a/src/biibaa/pipeline/run.py
+++ b/src/biibaa/pipeline/run.py
@@ -353,10 +353,9 @@ def run(
         ),
     )
 
-    out_dir = output_dir / run_at.strftime("%Y-%m-%d")
     paths: list[Path] = []
     for brief in top:
-        paths.append(write_brief(brief, out_dir))
+        paths.append(write_brief(brief, output_dir / brief.slug))
 
     advisory_src.close()
     downloads_src.close()
@@ -365,5 +364,5 @@ def run(
         e18e_src.close()
     if eco_src:
         eco_src.close()
-    log.info("pipeline.done", out_dir=str(out_dir), count=len(paths))
+    log.info("pipeline.done", output_dir=str(output_dir), count=len(paths))
     return paths


### PR DESCRIPTION
## Summary
- Brief output is now grouped by package: `data/briefs/<package-slug>/<yyyy-mm-dd>.md` instead of `data/briefs/<yyyy-mm-dd>/<package-slug>.md`.
- Each package gets its own directory; multiple runs accumulate as date-named files inside it, making per-package history easier to follow.
- Updated docs in `README.md` and `SPEC.md` to match the new layout.

## Changes
- `src/biibaa/pipeline/run.py` — per-brief `out_dir = output_dir / brief.slug`; `pipeline.done` log uses the root `output_dir` + `count`.
- `src/biibaa/briefs/render.py` — `write_brief` names the file by `brief.run_at` (`<yyyy-mm-dd>.md`); the per-package directory is the caller's responsibility.
- `README.md`, `SPEC.md` — layout references updated.

## Test plan
- [x] `uv run pytest -q` → 46/46 passed locally
- [ ] CI green
