### PR TITLE
fix(fanout): verify direct deps to drop transitive-only candidates

### DIFF
--- a/src/biibaa/adapters/github_repo.py
+++ b/src/biibaa/adapters/github_repo.py
@@ -6,10 +6,14 @@ are pulled in one query and cached together so `last_merged_pr_at` and
 - `last_merged_pr_at` feeds the confidence axis (a repo whose maintainers
   merged something last week is far more likely to merge a drive-by
   contribution than one frozen for two years).
-- `is_archived` is a hard disqualifier — archived repos won't accept PRs."""
+- `is_archived` is a hard disqualifier — archived repos won't accept PRs.
+- `fetch_direct_deps` reads the repo's HEAD `package.json` so the pipeline
+  can drop dependents that only pull in a flagged package transitively
+  (OSO's `sboms_v0` is lockfile-derived and includes the full tree)."""
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -24,6 +28,11 @@ from biibaa.adapters._http import make_client
 log = structlog.get_logger(__name__)
 
 GRAPHQL_URL = "https://api.github.com/graphql"
+
+# Sentinel returned by fetch_direct_deps for monorepo roots — enumerating
+# every workspace's package.json multiplies API cost and risks dropping
+# legit dependents, so callers treat this as "verified, don't filter".
+MONOREPO_SENTINEL = "*MONOREPO*"
 
 _QUERY = """
 query RepoMeta($owner: String!, $name: String!) {
@@ -79,6 +88,7 @@ class GithubRepoSource:
         self._token = _resolve_token(token)
         self._client = client or make_client(timeout=15.0)
         self._cache: dict[tuple[str, str], RepoMeta | None] = {}
+        self._direct_deps_cache: dict[tuple[str, str], set[str] | None] = {}
 
     def _headers(self) -> dict[str, str]:
         h = {"Accept": "application/vnd.github+json"}
@@ -135,6 +145,61 @@ class GithubRepoSource:
         # Unknown / unreachable repos are NOT treated as archived — better to
         # over-include than silently drop a project on a transient API blip.
         return bool(meta and meta.is_archived)
+
+    def fetch_direct_deps(self, *, repo_url: str) -> set[str] | None:
+        """Return the set of names listed in `dependencies`+`devDependencies`
+        of the repo's HEAD `package.json`.
+
+        Returns `None` on any failure (parse error, 404, network error) so
+        callers can treat the result as "unknown — don't filter". For monorepo
+        roots (a non-empty `workspaces` field), returns `{MONOREPO_SENTINEL}`
+        because enumerating each workspace's package.json multiplies API cost
+        and risks dropping legit dependents.
+        """
+        parsed = _parse_repo_url(repo_url)
+        if not parsed:
+            return None
+        if parsed in self._direct_deps_cache:
+            return self._direct_deps_cache[parsed]
+        owner, name = parsed
+        url = f"https://raw.githubusercontent.com/{owner}/{name}/HEAD/package.json"
+        try:
+            r = self._client.get(url, headers=self._headers())
+            r.raise_for_status()
+            payload = json.loads(r.text)
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError) as e:
+            log.warning(
+                "github_repo.fetch_direct_deps_failed",
+                repo=repo_url,
+                error=str(e),
+            )
+            self._direct_deps_cache[parsed] = None
+            return None
+
+        # Monorepo detection: `workspaces` may be an array or an object with
+        # a `packages` array (Yarn/Lerna style). Either form means this is a
+        # monorepo root — give benefit of doubt and verify-as-passed.
+        ws = payload.get("workspaces") if isinstance(payload, dict) else None
+        if isinstance(ws, list) and ws:
+            result: set[str] | None = {MONOREPO_SENTINEL}
+            self._direct_deps_cache[parsed] = result
+            return result
+        if isinstance(ws, dict):
+            pkgs = ws.get("packages")
+            if isinstance(pkgs, list) and pkgs:
+                result = {MONOREPO_SENTINEL}
+                self._direct_deps_cache[parsed] = result
+                return result
+
+        deps = payload.get("dependencies") if isinstance(payload, dict) else None
+        dev_deps = payload.get("devDependencies") if isinstance(payload, dict) else None
+        names: set[str] = set()
+        if isinstance(deps, dict):
+            names |= set(deps.keys())
+        if isinstance(dev_deps, dict):
+            names |= set(dev_deps.keys())
+        self._direct_deps_cache[parsed] = names
+        return names
 
     def close(self) -> None:
         self._client.close()

--- a/src/biibaa/pipeline/run.py
+++ b/src/biibaa/pipeline/run.py
@@ -23,7 +23,7 @@ import structlog
 from biibaa.adapters.dependents_factory import build_dependents_source
 from biibaa.adapters.e18e import E18eReplacementsSource
 from biibaa.adapters.github_advisories import GithubAdvisorySource
-from biibaa.adapters.github_repo import GithubRepoSource
+from biibaa.adapters.github_repo import MONOREPO_SENTINEL, GithubRepoSource
 from biibaa.adapters.npm_downloads import NpmDownloadsSource
 from biibaa.briefs.render import write_brief
 from biibaa.domain import Advisory, Brief, Opportunity, Project, Replacement
@@ -189,12 +189,18 @@ def _fan_out_dependents(
     downloads_src: NpmDownloadsSource,
     fanout_top_n: int,
     dependents_per_replacement: int,
+    repo_src: GithubRepoSource | None = None,
 ) -> list[tuple[Replacement, Dependent]]:
     """For the most-popular replacement candidates, pull top dependents.
 
     `fanout_top_n` caps how many e18e mappings we fan out from (ranked by
     the from-package's weekly downloads). Without this cap the API
     budget is too large.
+
+    When `repo_src` is provided, candidates are verified against each
+    dependent's HEAD `package.json` so we drop hits that only have the
+    flagged package as a *transitive* dep (OSO's `sboms_v0` is
+    lockfile-derived and includes the full tree).
     """
     deduped = _dedupe_replacements(replacements)
 
@@ -207,13 +213,56 @@ def _fan_out_dependents(
         reverse=True,
     )[:fanout_top_n]
 
-    out: list[tuple[Replacement, Dependent]] = []
+    candidates: list[tuple[Replacement, Dependent]] = []
     for r in ranked:
         name = _project_name_from_purl(r.from_purl)
         deps = eco_src.fetch_dependents(package=name, top_k=dependents_per_replacement)
         log.info("fanout.dependents", from_pkg=name, count=len(deps))
         for d in deps:
-            out.append((r, d))
+            candidates.append((r, d))
+
+    if repo_src is None:
+        return candidates
+
+    out: list[tuple[Replacement, Dependent]] = []
+    kept = dropped = unknown = monorepo = 0
+    for rep, dep in candidates:
+        from_name = _project_name_from_purl(rep.from_purl)
+        if not dep.repo_url:
+            # No repo URL — can't verify, keep it.
+            unknown += 1
+            kept += 1
+            out.append((rep, dep))
+            continue
+        direct = repo_src.fetch_direct_deps(repo_url=dep.repo_url)
+        if direct is None:
+            unknown += 1
+            kept += 1
+            out.append((rep, dep))
+            continue
+        if MONOREPO_SENTINEL in direct:
+            monorepo += 1
+            kept += 1
+            out.append((rep, dep))
+            continue
+        if from_name in direct:
+            kept += 1
+            out.append((rep, dep))
+            continue
+        log.info(
+            "fanout.dropped_transitive_only",
+            from_pkg=from_name,
+            dependent=dep.name,
+            repo_url=dep.repo_url,
+        )
+        dropped += 1
+    log.info(
+        "fanout.direct_deps_filter",
+        kept=kept,
+        dropped=dropped,
+        unknown=unknown,
+        monorepo=monorepo,
+    )
     return out
 
 
@@ -259,6 +308,7 @@ def run(
             downloads_src=downloads_src,
             fanout_top_n=fanout_top_n,
             dependents_per_replacement=dependents_per_replacement,
+            repo_src=repo_src,
         )
         log.info("pipeline.fanouts_built", count=len(fanouts))
 

--- a/tests/test_direct_deps_filter.py
+++ b/tests/test_direct_deps_filter.py
@@ -1,0 +1,294 @@
+"""Direct-dep verification — drop fan-out candidates whose package.json
+doesn't list the from-package as a direct dependency.
+
+Root cause: OSO `sboms_v0` is lockfile-derived and includes the full
+transitive tree, so unverified fan-outs end up recommending packages
+to repos that only pull them in via dev tooling (jest, release-please,
+etc.). This filter compares against the repo's HEAD `package.json`.
+"""
+
+from __future__ import annotations
+
+import httpx
+from pytest_httpx import HTTPXMock
+
+from biibaa.adapters.github_repo import MONOREPO_SENTINEL, GithubRepoSource
+from biibaa.domain import Replacement
+from biibaa.pipeline.run import _fan_out_dependents
+from biibaa.ports.dependents import Dependent
+
+# ---------- GithubRepoSource.fetch_direct_deps ----------
+
+
+def test_fetch_direct_deps_merges_dependencies_and_dev_dependencies(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={
+            "name": "bar",
+            "dependencies": {"lodash": "^4.0.0", "react": "^18.0.0"},
+            "devDependencies": {"jest": "^29.0.0"},
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    got = src.fetch_direct_deps(repo_url="https://github.com/foo/bar")
+    assert got == {"lodash", "react", "jest"}
+
+
+def test_fetch_direct_deps_returns_empty_set_when_manifest_has_no_deps(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={"name": "bar", "version": "1.0.0"},
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    got = src.fetch_direct_deps(repo_url="https://github.com/foo/bar")
+    assert got == set()
+
+
+def test_fetch_direct_deps_returns_monorepo_sentinel_for_array_workspaces(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/mono/repo/HEAD/package.json",
+        method="GET",
+        json={
+            "name": "mono",
+            "private": True,
+            "workspaces": ["packages/*", "apps/*"],
+            "dependencies": {"lodash": "^4.0.0"},
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    got = src.fetch_direct_deps(repo_url="https://github.com/mono/repo")
+    assert got == {MONOREPO_SENTINEL}
+
+
+def test_fetch_direct_deps_returns_monorepo_sentinel_for_object_workspaces(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/mono/repo/HEAD/package.json",
+        method="GET",
+        json={
+            "name": "mono",
+            "workspaces": {
+                "packages": ["packages/*"],
+                "nohoist": ["**/foo"],
+            },
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    got = src.fetch_direct_deps(repo_url="https://github.com/mono/repo")
+    assert got == {MONOREPO_SENTINEL}
+
+
+def test_fetch_direct_deps_returns_none_on_404(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/ghost/missing/HEAD/package.json",
+        method="GET",
+        status_code=404,
+        text="404: Not Found",
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    assert src.fetch_direct_deps(repo_url="https://github.com/ghost/missing") is None
+
+
+def test_fetch_direct_deps_returns_none_on_invalid_json(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        text="<!DOCTYPE html>not json",
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    assert src.fetch_direct_deps(repo_url="https://github.com/foo/bar") is None
+
+
+def test_fetch_direct_deps_caches_per_repo(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={"dependencies": {"x": "1"}},
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    a = src.fetch_direct_deps(repo_url="https://github.com/foo/bar")
+    b = src.fetch_direct_deps(repo_url="https://github.com/foo/bar")
+    assert a == b == {"x"}
+    # Only one mock registered — pytest-httpx fails teardown if a 2nd hit fired.
+
+
+# ---------- pipeline-level filter ----------
+
+
+class _StubEcoSrc:
+    name = "stub"
+
+    def __init__(self, dependents: list[Dependent]) -> None:
+        self._dependents = dependents
+
+    def fetch_dependents(self, *, package: str, top_k: int = 10) -> list[Dependent]:
+        return self._dependents
+
+    def close(self) -> None:
+        pass
+
+
+class _StubDownloadsSrc:
+    """Returns fixed weekly download counts. Avoids real npm calls."""
+
+    def __init__(self, counts: dict[str, int]) -> None:
+        self._counts = counts
+
+    def weekly_downloads_bulk(
+        self, *, packages: list[str]
+    ) -> dict[str, int | None]:
+        return {p: self._counts.get(p) for p in packages}
+
+    def close(self) -> None:
+        pass
+
+
+def _replacement(from_name: str) -> Replacement:
+    return Replacement(
+        id=f"e18e:{from_name}",
+        from_purl=f"pkg:npm/{from_name}",
+        to_purls=["pkg:npm/<native>"],
+        axis="bloat",
+        effort="drop-in",
+    )
+
+
+def _dep(name: str, repo_url: str | None) -> Dependent:
+    return Dependent(
+        name=name,
+        purl=f"pkg:npm/{name}",
+        repo_url=repo_url,
+        lifetime_downloads=None,
+    )
+
+
+def _make_repo_src(client: httpx.Client) -> GithubRepoSource:
+    return GithubRepoSource(token="x", client=client)
+
+
+def test_filter_drops_candidate_without_direct_dep(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """uuid-style case: lodash.snakecase only present transitively."""
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/uuidjs/uuid/HEAD/package.json",
+        method="GET",
+        json={
+            "name": "uuid",
+            "dependencies": {},
+            "devDependencies": {"jest": "^29", "release-please": "^16"},
+        },
+    )
+    eco = _StubEcoSrc(
+        [_dep("uuid", "https://github.com/uuidjs/uuid")]
+    )
+    downloads = _StubDownloadsSrc({"lodash.snakecase": 5_000_000})
+    repo_src = _make_repo_src(httpx.Client())
+    out = _fan_out_dependents(
+        replacements=[_replacement("lodash.snakecase")],
+        eco_src=eco,  # type: ignore[arg-type]
+        downloads_src=downloads,  # type: ignore[arg-type]
+        fanout_top_n=10,
+        dependents_per_replacement=5,
+        repo_src=repo_src,
+    )
+    assert out == []
+
+
+def test_filter_keeps_candidate_with_direct_dep(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/some/consumer/HEAD/package.json",
+        method="GET",
+        json={"dependencies": {"lodash.snakecase": "^4.0.0"}},
+    )
+    eco = _StubEcoSrc(
+        [_dep("consumer", "https://github.com/some/consumer")]
+    )
+    downloads = _StubDownloadsSrc({"lodash.snakecase": 5_000_000})
+    repo_src = _make_repo_src(httpx.Client())
+    out = _fan_out_dependents(
+        replacements=[_replacement("lodash.snakecase")],
+        eco_src=eco,  # type: ignore[arg-type]
+        downloads_src=downloads,  # type: ignore[arg-type]
+        fanout_top_n=10,
+        dependents_per_replacement=5,
+        repo_src=repo_src,
+    )
+    assert [d.name for _, d in out] == ["consumer"]
+
+
+def test_filter_keeps_candidate_when_verification_returns_none(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """404 / parse error → unknown, don't filter."""
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/some/private/HEAD/package.json",
+        method="GET",
+        status_code=404,
+    )
+    eco = _StubEcoSrc(
+        [_dep("private-pkg", "https://github.com/some/private")]
+    )
+    downloads = _StubDownloadsSrc({"lodash.snakecase": 5_000_000})
+    repo_src = _make_repo_src(httpx.Client())
+    out = _fan_out_dependents(
+        replacements=[_replacement("lodash.snakecase")],
+        eco_src=eco,  # type: ignore[arg-type]
+        downloads_src=downloads,  # type: ignore[arg-type]
+        fanout_top_n=10,
+        dependents_per_replacement=5,
+        repo_src=repo_src,
+    )
+    assert [d.name for _, d in out] == ["private-pkg"]
+
+
+def test_filter_keeps_candidate_for_monorepo_root(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/big/mono/HEAD/package.json",
+        method="GET",
+        json={
+            "name": "mono",
+            "private": True,
+            "workspaces": ["packages/*"],
+            "devDependencies": {"jest": "^29"},
+        },
+    )
+    eco = _StubEcoSrc(
+        [_dep("mono", "https://github.com/big/mono")]
+    )
+    downloads = _StubDownloadsSrc({"lodash.snakecase": 5_000_000})
+    repo_src = _make_repo_src(httpx.Client())
+    out = _fan_out_dependents(
+        replacements=[_replacement("lodash.snakecase")],
+        eco_src=eco,  # type: ignore[arg-type]
+        downloads_src=downloads,  # type: ignore[arg-type]
+        fanout_top_n=10,
+        dependents_per_replacement=5,
+        repo_src=repo_src,
+    )
+    assert [d.name for _, d in out] == ["mono"]
+
+
+def test_filter_disabled_when_repo_src_is_none() -> None:
+    """No repo_src kwarg → original behavior, return all candidates."""
+    eco = _StubEcoSrc(
+        [_dep("transitive-only", "https://github.com/foo/bar")]
+    )
+    downloads = _StubDownloadsSrc({"lodash.snakecase": 5_000_000})
+    out = _fan_out_dependents(
+        replacements=[_replacement("lodash.snakecase")],
+        eco_src=eco,  # type: ignore[arg-type]
+        downloads_src=downloads,  # type: ignore[arg-type]
+        fanout_top_n=10,
+        dependents_per_replacement=5,
+    )
+    assert [d.name for _, d in out] == ["transitive-only"]


### PR DESCRIPTION
## Summary
- Replacement-axis briefs were targeting repos that don't actually have the flagged package as a direct dep — e.g. `uuidjs/uuid` told to drop `lodash.snakecase`, which only appears transitively via dev tooling.
- Root cause: `PyosoSource.fetch_dependents` queries OSO's `oso.sboms_v0`, which is **lockfile-derived** and contains the full transitive tree. The mart exposes no relationship/dep_type column, so SQL-level filtering is impossible.
- Fix: post-fetch verify each candidate against the dependent repo's HEAD `package.json` and drop entries where the from-package isn't listed in `dependencies` or `devDependencies`.

## How it works
- New `GithubRepoSource.fetch_direct_deps(repo_url) -> set[str] | None`. Hits `raw.githubusercontent.com/{owner}/{repo}/HEAD/package.json`, returns the union of `dependencies` + `devDependencies` keys.
- **Monorepo handling**: roots with a `workspaces` field (array or `{packages: [...]}` object) return a `MONOREPO_SENTINEL` and pass through unfiltered — enumerating each workspace's `package.json` would multiply API cost.
- **Failures**: 404 / network error / parse error returns `None` → candidate kept (better to over-include than silently drop).
- `_fan_out_dependents` accepts a new `repo_src` kwarg and runs the filter; emits `fanout.direct_deps_filter` log with `kept`/`dropped`/`unknown`/`monorepo` counts.

## Test plan
- [x] `uv run pytest -q` → 58 passed, 1 skipped (pre-existing `pyoso` optional-extra skip), 0 failed
- [x] 12 new tests in `tests/test_direct_deps_filter.py` covering deps merge, both monorepo shapes, 404, invalid JSON, cache, drop/keep paths, and `repo_src=None` pass-through
- [ ] Re-run pipeline post-merge and confirm `uuidjs__uuid` no longer recommends `lodash.snakecase`

See investigation thread for full lineage trace through `int_sbom_to_packages` → `int_sbom__latest_snapshot` → `stg_ossd__current_sbom`.
