### PR TITLE
feat(brief): surface bench-presence signal for triage

### DIFF
--- a/src/biibaa/adapters/github_repo.py
+++ b/src/biibaa/adapters/github_repo.py
@@ -39,12 +39,23 @@ MONOREPO_SENTINEL = "*MONOREPO*"
 
 # Bench libraries we trust as a signal that the repo has runnable benchmarks.
 # Conservative on purpose — vitest/jest are bench-capable but their bench
-# command is opt-in and noisy as a signal, so we exclude them.
+# command is opt-in. Their devDep presence alone is too noisy; the
+# vitest/jest bench case is handled via _BENCH_CMD_PATTERNS below instead.
 _BENCH_DEV_DEPS: tuple[str, ...] = (
     "tinybench",
     "mitata",
     "benchmark",
     "cronometro",
+)
+
+# Catches `scripts.<key>` whose VALUE invokes vitest/jest in bench mode but
+# whose NAME doesn't contain "bench" (e.g. `"test:perf": "vitest bench src/"`).
+# The `[^&|;]*` guard stops matching at shell command separators, so
+# `"build && vitest && bench-something"` does NOT match — vitest there isn't
+# the thing running bench.
+_BENCH_CMD_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bvitest\s+[^&|;]*bench", re.IGNORECASE),
+    re.compile(r"\bjest\s+[^&|;]*bench", re.IGNORECASE),
 )
 
 _QUERY = """
@@ -242,9 +253,22 @@ class GithubRepoSource:
             return (False, None)
         scripts = payload.get("scripts")
         if isinstance(scripts, dict):
+            # 1. Script NAME contains "bench" — most direct signal.
             for script_name in scripts:
                 if isinstance(script_name, str) and "bench" in script_name.lower():
                     return (True, f"script:{script_name}")
+            # 2. Script VALUE invokes vitest/jest in bench mode. Catches the
+            #    common case where the script name is generic ("test:perf",
+            #    "ci") but the command body runs vitest's bench feature.
+            for script_name, script_value in scripts.items():
+                if not isinstance(script_name, str) or not isinstance(
+                    script_value, str
+                ):
+                    continue
+                for pat in _BENCH_CMD_PATTERNS:
+                    if pat.search(script_value):
+                        return (True, f"script-cmd:{script_name}")
+        # 3. Known bench-only devDep — independent of any script.
         for field in ("devDependencies", "dependencies"):
             section = payload.get(field)
             if isinstance(section, dict):

--- a/src/biibaa/adapters/github_repo.py
+++ b/src/biibaa/adapters/github_repo.py
@@ -9,7 +9,10 @@ are pulled in one query and cached together so `last_merged_pr_at` and
 - `is_archived` is a hard disqualifier — archived repos won't accept PRs.
 - `fetch_direct_deps` reads the repo's HEAD `package.json` so the pipeline
   can drop dependents that only pull in a flagged package transitively
-  (OSO's `sboms_v0` is lockfile-derived and includes the full tree)."""
+  (OSO's `sboms_v0` is lockfile-derived and includes the full tree).
+- `bench_info` derives a yes/no benchmark signal from the same cached
+  `package.json` (zero extra HTTP) — repos with benchmarks are the easiest
+  triage targets for perf-replacement briefs."""
 
 from __future__ import annotations
 
@@ -33,6 +36,16 @@ GRAPHQL_URL = "https://api.github.com/graphql"
 # every workspace's package.json multiplies API cost and risks dropping
 # legit dependents, so callers treat this as "verified, don't filter".
 MONOREPO_SENTINEL = "*MONOREPO*"
+
+# Bench libraries we trust as a signal that the repo has runnable benchmarks.
+# Conservative on purpose — vitest/jest are bench-capable but their bench
+# command is opt-in and noisy as a signal, so we exclude them.
+_BENCH_DEV_DEPS: tuple[str, ...] = (
+    "tinybench",
+    "mitata",
+    "benchmark",
+    "cronometro",
+)
 
 _QUERY = """
 query RepoMeta($owner: String!, $name: String!) {
@@ -88,7 +101,9 @@ class GithubRepoSource:
         self._token = _resolve_token(token)
         self._client = client or make_client(timeout=15.0)
         self._cache: dict[tuple[str, str], RepoMeta | None] = {}
-        self._direct_deps_cache: dict[tuple[str, str], set[str] | None] = {}
+        # Caches the parsed package.json so fetch_direct_deps and bench_info
+        # share a single HTTP round-trip per repo. None = fetch/parse failed.
+        self._pkg_cache: dict[tuple[str, str], dict | None] = {}
 
     def _headers(self) -> dict[str, str]:
         h = {"Accept": "application/vnd.github+json"}
@@ -146,6 +161,37 @@ class GithubRepoSource:
         # over-include than silently drop a project on a transient API blip.
         return bool(meta and meta.is_archived)
 
+    def _fetch_pkg_json(self, *, repo_url: str) -> dict | None:
+        """Fetch + parse the repo's HEAD package.json, cached per repo.
+
+        Returns the parsed JSON object, or None on any failure (parse error,
+        404, network error, non-object payload).
+        """
+        parsed = _parse_repo_url(repo_url)
+        if not parsed:
+            return None
+        if parsed in self._pkg_cache:
+            return self._pkg_cache[parsed]
+        owner, name = parsed
+        url = f"https://raw.githubusercontent.com/{owner}/{name}/HEAD/package.json"
+        try:
+            r = self._client.get(url, headers=self._headers())
+            r.raise_for_status()
+            payload = json.loads(r.text)
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError) as e:
+            log.warning(
+                "github_repo.fetch_pkg_failed",
+                repo=repo_url,
+                error=str(e),
+            )
+            self._pkg_cache[parsed] = None
+            return None
+        if not isinstance(payload, dict):
+            self._pkg_cache[parsed] = None
+            return None
+        self._pkg_cache[parsed] = payload
+        return payload
+
     def fetch_direct_deps(self, *, repo_url: str) -> set[str] | None:
         """Return the set of names listed in `dependencies`+`devDependencies`
         of the repo's HEAD `package.json`.
@@ -156,50 +202,56 @@ class GithubRepoSource:
         because enumerating each workspace's package.json multiplies API cost
         and risks dropping legit dependents.
         """
-        parsed = _parse_repo_url(repo_url)
-        if not parsed:
-            return None
-        if parsed in self._direct_deps_cache:
-            return self._direct_deps_cache[parsed]
-        owner, name = parsed
-        url = f"https://raw.githubusercontent.com/{owner}/{name}/HEAD/package.json"
-        try:
-            r = self._client.get(url, headers=self._headers())
-            r.raise_for_status()
-            payload = json.loads(r.text)
-        except (httpx.HTTPError, json.JSONDecodeError, ValueError) as e:
-            log.warning(
-                "github_repo.fetch_direct_deps_failed",
-                repo=repo_url,
-                error=str(e),
-            )
-            self._direct_deps_cache[parsed] = None
+        payload = self._fetch_pkg_json(repo_url=repo_url)
+        if payload is None:
             return None
 
         # Monorepo detection: `workspaces` may be an array or an object with
         # a `packages` array (Yarn/Lerna style). Either form means this is a
         # monorepo root — give benefit of doubt and verify-as-passed.
-        ws = payload.get("workspaces") if isinstance(payload, dict) else None
+        ws = payload.get("workspaces")
         if isinstance(ws, list) and ws:
-            result: set[str] | None = {MONOREPO_SENTINEL}
-            self._direct_deps_cache[parsed] = result
-            return result
+            return {MONOREPO_SENTINEL}
         if isinstance(ws, dict):
             pkgs = ws.get("packages")
             if isinstance(pkgs, list) and pkgs:
-                result = {MONOREPO_SENTINEL}
-                self._direct_deps_cache[parsed] = result
-                return result
+                return {MONOREPO_SENTINEL}
 
-        deps = payload.get("dependencies") if isinstance(payload, dict) else None
-        dev_deps = payload.get("devDependencies") if isinstance(payload, dict) else None
+        deps = payload.get("dependencies")
+        dev_deps = payload.get("devDependencies")
         names: set[str] = set()
         if isinstance(deps, dict):
             names |= set(deps.keys())
         if isinstance(dev_deps, dict):
             names |= set(dev_deps.keys())
-        self._direct_deps_cache[parsed] = names
         return names
+
+    def bench_info(self, *, repo_url: str) -> tuple[bool, str | None]:
+        """Detect runnable-benchmark signals in the repo's HEAD package.json.
+
+        Cheap heuristic — no AST, no execution. Reuses the same cached
+        `package.json` as `fetch_direct_deps`, so callers that have already
+        fan-out-filtered against direct deps pay zero extra HTTP for this.
+
+        Returns `(has_benchmarks, signal)`. `signal` is a short label like
+        `"script:bench"` or `"devDep:tinybench"` for the brief render.
+        Returns `(False, None)` when unreachable or no signal found.
+        """
+        payload = self._fetch_pkg_json(repo_url=repo_url)
+        if payload is None:
+            return (False, None)
+        scripts = payload.get("scripts")
+        if isinstance(scripts, dict):
+            for script_name in scripts:
+                if isinstance(script_name, str) and "bench" in script_name.lower():
+                    return (True, f"script:{script_name}")
+        for field in ("devDependencies", "dependencies"):
+            section = payload.get(field)
+            if isinstance(section, dict):
+                for lib in _BENCH_DEV_DEPS:
+                    if lib in section:
+                        return (True, f"devDep:{lib}")
+        return (False, None)
 
     def close(self) -> None:
         self._client.close()

--- a/src/biibaa/briefs/templates/brief.md.j2
+++ b/src/biibaa/briefs/templates/brief.md.j2
@@ -5,6 +5,11 @@
 - **Popularity**: {{ ("{:,}".format(project.downloads_weekly) ~ ' downloads/wk') if project.downloads_weekly else '—' }}
 - **Score**: {{ "%.1f"|format(score) }} (impact {{ "%.1f"|format(impact) }}, effort {{ "%.1f"|format(effort) }}, confidence {{ "%.0f"|format(confidence_value) }})
 - **Maintainer activity**: {{ activity_label }}
+{% if project.has_benchmarks %}
+- **Benchmarks**: yes — `{{ project.bench_signal }}` (perf changes are falsifiable in this repo)
+{% elif project.has_benchmarks is sameas false %}
+- **Benchmarks**: none detected in HEAD `package.json`
+{% endif %}
 
 ## Top opportunities
 

--- a/src/biibaa/domain/models.py
+++ b/src/biibaa/domain/models.py
@@ -29,6 +29,8 @@ class Project(_Frozen):
     last_commit_at: datetime | None = None
     last_pr_merged_at: datetime | None = None
     archived: bool = False
+    has_benchmarks: bool | None = None
+    bench_signal: str | None = None
 
 
 class Advisory(_Frozen):

--- a/src/biibaa/pipeline/run.py
+++ b/src/biibaa/pipeline/run.py
@@ -65,6 +65,8 @@ def _project_from(
     *,
     last_pr_merged_at: datetime | None = None,
     archived: bool = False,
+    has_benchmarks: bool | None = None,
+    bench_signal: str | None = None,
 ) -> Project:
     return Project(
         purl=purl,
@@ -74,6 +76,8 @@ def _project_from(
         repo_url=repo_url,
         last_pr_merged_at=last_pr_merged_at,
         archived=archived,
+        has_benchmarks=has_benchmarks,
+        bench_signal=bench_signal,
     )
 
 
@@ -338,6 +342,13 @@ def run(
             if findings.repo_url
             else None
         )
+        # Only read bench info for replacement-driven projects: fan-out has
+        # already fetched their package.json so this is a free cache hit.
+        # Skipping vuln-only projects keeps the HTTP budget unchanged.
+        has_bench: bool | None = None
+        bench_signal: str | None = None
+        if findings.repo_url and findings.replacements:
+            has_bench, bench_signal = repo_src.bench_info(repo_url=findings.repo_url)
         projects[purl] = _project_from(
             purl,
             ecosystem,
@@ -345,6 +356,8 @@ def run(
             findings.repo_url,
             last_pr_merged_at=meta.last_merged_pr_at if meta else None,
             archived=meta.is_archived if meta else False,
+            has_benchmarks=has_bench,
+            bench_signal=bench_signal,
         )
 
     skipped = sum(

--- a/tests/test_bench_info.py
+++ b/tests/test_bench_info.py
@@ -1,0 +1,123 @@
+"""Bench-presence detection on `GithubRepoSource.bench_info`.
+
+The signal is a low-cost triage hint, not a scoring input — a repo that
+maintains benchmarks is the easiest target for a perf-replacement PR
+because the change can be falsified against the repo's own harness.
+
+Detection is heuristic and runs against the HEAD `package.json` we
+already fetch for direct-dep verification (zero extra HTTP per repo).
+"""
+
+from __future__ import annotations
+
+import httpx
+from pytest_httpx import HTTPXMock
+
+from biibaa.adapters.github_repo import GithubRepoSource
+
+
+def test_bench_info_detects_bench_script(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={
+            "name": "bar",
+            "scripts": {"test": "vitest", "bench": "node bench.js"},
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
+    assert has_bench is True
+    assert signal == "script:bench"
+
+
+def test_bench_info_detects_namespaced_bench_script(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={"scripts": {"benchmark:run": "tinybench bench/*"}},
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
+    assert has_bench is True
+    assert signal == "script:benchmark:run"
+
+
+def test_bench_info_detects_known_bench_devdep(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={
+            "scripts": {"test": "vitest"},
+            "devDependencies": {"tinybench": "^2.0.0", "vitest": "^1.0.0"},
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
+    assert has_bench is True
+    assert signal == "devDep:tinybench"
+
+
+def test_bench_info_returns_false_when_no_signal(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={
+            "name": "bar",
+            "scripts": {"test": "vitest", "lint": "eslint ."},
+            "devDependencies": {"vitest": "^1.0.0", "eslint": "^9.0.0"},
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
+    assert has_bench is False
+    assert signal is None
+
+
+def test_bench_info_returns_false_when_pkg_unreachable(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/ghost/missing/HEAD/package.json",
+        method="GET",
+        status_code=404,
+        text="404",
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    has_bench, signal = src.bench_info(repo_url="https://github.com/ghost/missing")
+    assert has_bench is False
+    assert signal is None
+
+
+def test_bench_info_shares_cache_with_fetch_direct_deps(httpx_mock: HTTPXMock) -> None:
+    """One HTTP call must serve both direct-deps verification and bench_info.
+
+    This is the only reason it's safe to enable bench detection in the
+    pipeline — it piggybacks on the package.json fan-out already does.
+    """
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={
+            "dependencies": {"react": "^18.0.0"},
+            "devDependencies": {"mitata": "^0.1.0"},
+            "scripts": {"build": "tsc"},
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    deps = src.fetch_direct_deps(repo_url="https://github.com/foo/bar")
+    has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
+    assert deps == {"react", "mitata"}
+    assert has_bench is True
+    assert signal == "devDep:mitata"
+    # No second mock registered — pytest-httpx fails teardown if a 2nd hit fired.
+
+
+def test_bench_info_script_match_is_case_insensitive(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={"scripts": {"Bench": "node bench.js"}},
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
+    assert has_bench is True
+    assert signal == "script:Bench"

--- a/tests/test_bench_info.py
+++ b/tests/test_bench_info.py
@@ -121,3 +121,104 @@ def test_bench_info_script_match_is_case_insensitive(httpx_mock: HTTPXMock) -> N
     has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
     assert has_bench is True
     assert signal == "script:Bench"
+
+
+# ---------- script-value scan (vitest/jest bench commands) ----------
+
+
+def test_bench_info_detects_vitest_bench_in_script_value(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Catches vitest's bench command when the script name lacks "bench"."""
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={
+            "scripts": {"test:perf": "vitest bench src/"},
+            "devDependencies": {"vitest": "^1.0.0"},
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
+    assert has_bench is True
+    assert signal == "script-cmd:test:perf"
+
+
+def test_bench_info_detects_jest_bench_in_script_value(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={
+            "scripts": {"perf": "jest --testPathPattern bench"},
+            "devDependencies": {"jest": "^29.0.0"},
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
+    assert has_bench is True
+    assert signal == "script-cmd:perf"
+
+
+def test_bench_info_does_not_match_plain_vitest(httpx_mock: HTTPXMock) -> None:
+    """`vitest` alone is just a test runner — no bench signal expected."""
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={
+            "scripts": {"test": "vitest", "ci": "vitest run"},
+            "devDependencies": {"vitest": "^1.0.0"},
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
+    assert has_bench is False
+    assert signal is None
+
+
+def test_bench_info_value_match_stops_at_command_separator(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """vitest is unrelated to the later "bench-something" — must not match."""
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={"scripts": {"ci": "vitest && build && bench-something"}},
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
+    assert has_bench is False
+    assert signal is None
+
+
+def test_bench_info_name_match_takes_priority_over_value_match(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """When both fire, the name-match path wins — it's a more direct signal."""
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={
+            "scripts": {
+                "bench": "node bench.js",
+                "test:perf": "vitest bench src/",
+            }
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
+    assert has_bench is True
+    assert signal == "script:bench"
+
+
+def test_bench_info_value_match_is_case_insensitive(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        method="GET",
+        json={"scripts": {"PerfTest": "VITEST BENCH src/"}},
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    has_bench, signal = src.bench_info(repo_url="https://github.com/foo/bar")
+    assert has_bench is True
+    assert signal == "script-cmd:PerfTest"


### PR DESCRIPTION
## Summary

- Surface a **benchmark-presence signal** in each brief so triagers can
  pick repos where a perf-replacement PR can be falsified against the
  repo's own harness.
- Detection is heuristic and read straight from the HEAD `package.json`
  we already fetch for direct-dep verification — **zero new HTTP calls**.
- Pure triage hint — no scoring change, no AST, no reachability, no
  benchmark execution.

## How it works

`GithubRepoSource.bench_info(repo_url)` returns `(has_benchmarks, signal)`,
deriving from a single cached package.json fetch shared with
`fetch_direct_deps`. Signal is a short label that encodes the detection
path so reviewers and the future website can debug false positives.

Detection rules (run in order, first hit wins):

| # | Rule | Signal label | Matches |
|---|---|---|---|
| 1 | `scripts.<key>` whose NAME contains `bench` (case-insensitive) | `script:<name>` | `"bench"`, `"benchmark:run"` |
| 2 | `scripts.<key>` whose VALUE matches `\bvitest\s+[^&\|;]*bench` or `\bjest\s+[^&\|;]*bench` | `script-cmd:<name>` | `"test:perf": "vitest bench src/"`, `"perf": "jest --testPathPattern bench"` |
| 3 | `tinybench`, `mitata`, `benchmark`, or `cronometro` in `devDependencies` (or `dependencies`) | `devDep:<lib>` | dedicated bench libs |

Rule 2 is the answer to the "vitest/jest are bench-capable but noisy"
problem from the original draft. Adding vitest/jest to the devDep
allowlist would over-detect every vitest user; instead we check that
the script's COMMAND BODY actually invokes vitest/jest with "bench" in
the args. The `[^&|;]*` guard stops matching at shell command
separators, so `"vitest && build && bench-something"` does NOT match —
vitest there isn't the thing running bench.

Pipeline only calls `bench_info` for replacement-driven projects, where
fan-out has already cached the package.json. Vuln-only projects stay
unmarked — keeps the HTTP budget identical to before.

The brief renders three states:
- **yes** — `**Benchmarks**: yes — `devDep:tinybench` (perf changes are falsifiable in this repo)`
- **no** — `**Benchmarks**: none detected in HEAD package.json`
- **unknown** — line omitted entirely

## Deferred

Per [the design discussion](https://github.com/OpenHackersClub/biibaa/pull/11#issuecomment-4324698017),
deferring these until telemetry justifies the cost:

- **GitHub Trees API check for `*.bench.{ts,js,mjs}` files** — would catch
  vitest-bench repos that rely on file convention with no "bench" token in
  any script. +1 HTTP per ambiguous repo. Land only if recall gap matters.
- **Tiered-confidence return type** (`high`/`medium`/`low`) — purely
  cosmetic until the website needs it.
- **Jest custom-harness detection** — long tail; AST work for marginal gain.

## Test plan

- [x] `uv run pytest` — 76/76 pass (13 in `tests/test_bench_info.py`)
- [x] `uv run ruff check src tests` — clean
- [x] `uv run mypy src` — same 3 pre-existing errors as `main`, no new
- [x] Template render smoke-test for yes / no / unknown states
- [x] Cache-reuse property tested: one HTTP call serves both
      `fetch_direct_deps` and `bench_info`
- [x] Boundary tested: `vitest && build && bench-x` does NOT match
- [x] Priority tested: name-match wins over value-match when both fire
