### PR TITLE
docs(env): add env.sample and configuration section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ data/
 .vscode/
 .idea/
 .DS_Store
+
+# Local env (copy from env.sample)
+.env
+.env.local

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ uv run biibaa run --top 20
 
 Briefs land in `data/briefs/<project>/<yyyy-mm-dd>.md`.
 
+## Configuration
+
+Copy `env.sample` to `.env` (gitignored) and fill in what you need.
+
+- `GITHUB_TOKEN` — required for non-trivial runs (REST rate limits bite
+  fast). Falls back to `gh auth token` if the `gh` CLI is logged in.
+- `OSO_API_KEY` — optional. With the `pyoso` extra installed
+  (`uv sync --extra pyoso`), enables the tiered dependents source backed
+  by OSO's `sboms_v0` join. Without it, ecosyste.ms is the sole backend.
+- TLS / proxy vars (`BIIBAA_INSECURE_TLS`, `SSL_CERT_FILE`,
+  `REQUESTS_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`, `HTTPS_PROXY`,
+  `HTTP_PROXY`) — see [Behind a MITM proxy](#behind-a-mitm-proxy) below.
+
 ## What you'll see
 
 **Every brief points at one specific repo a contributor can PR.**

--- a/env.sample
+++ b/env.sample
@@ -1,0 +1,27 @@
+# ---- GitHub API auth (required for non-trivial runs) ----
+# PAT or OAuth token. Used by github_advisories + github_repo. Falls back
+# to `gh auth token` subprocess if unset, but rate limits are tighter without.
+GITHUB_TOKEN=
+
+# ---- OSO BigQuery (optional — enables tiered dependents source) ----
+# When set AND the `pyoso` extra is installed, dependents fan-out uses the
+# OSO sboms_v0 join as primary, with ecosyste.ms as fallback. Without it,
+# ecosyste.ms is used alone.
+OSO_API_KEY=
+
+# ---- TLS / MITM proxy (optional — only needed behind a proxy) ----
+# Force-disable cert verification for outbound calls. Use only when behind
+# a loopback MITM proxy (e.g. `ccli net start`).
+BIIBAA_INSECURE_TLS=
+
+# Extra CA bundle paths honored by the shared httpx client. Set whichever
+# your proxy / runtime expects — the first existing one wins.
+SSL_CERT_FILE=
+REQUESTS_CA_BUNDLE=
+NODE_EXTRA_CA_CERTS=
+
+# When HTTPS_PROXY/HTTP_PROXY points at 127.0.0.1 or localhost, the client
+# auto-disables verification on that hop. Standard names — set them only
+# if you actually run a proxy.
+HTTPS_PROXY=
+HTTP_PROXY=

--- a/env.sample
+++ b/env.sample
@@ -8,20 +8,3 @@ GITHUB_TOKEN=
 # OSO sboms_v0 join as primary, with ecosyste.ms as fallback. Without it,
 # ecosyste.ms is used alone.
 OSO_API_KEY=
-
-# ---- TLS / MITM proxy (optional — only needed behind a proxy) ----
-# Force-disable cert verification for outbound calls. Use only when behind
-# a loopback MITM proxy (e.g. `ccli net start`).
-BIIBAA_INSECURE_TLS=
-
-# Extra CA bundle paths honored by the shared httpx client. Set whichever
-# your proxy / runtime expects — the first existing one wins.
-SSL_CERT_FILE=
-REQUESTS_CA_BUNDLE=
-NODE_EXTRA_CA_CERTS=
-
-# When HTTPS_PROXY/HTTP_PROXY points at 127.0.0.1 or localhost, the client
-# auto-disables verification on that hop. Standard names — set them only
-# if you actually run a proxy.
-HTTPS_PROXY=
-HTTP_PROXY=


### PR DESCRIPTION
## Summary

- Populate the empty `env.sample` with the project-specific env vars
  (`GITHUB_TOKEN`, `OSO_API_KEY`), grouped and commented so a new
  contributor can copy-and-fill in one pass.
- Add `.env` and `.env.local` to `.gitignore` — they were missing, so
  anyone copying `env.sample` to `.env` to add secrets risked committing
  them.
- Add a short `## Configuration` section to the README between
  Quickstart and What you'll see. Points at the existing
  "Behind a MITM proxy" section for TLS / proxy details rather than
  duplicating.

## Scope

Docs/config only — no source or test changes.

`env.sample` is intentionally **project-specific** vars only. 
## Test plan

- [x] `uv run pytest -q` — full suite passes (no source changed)
- [x] `uv run ruff check src tests` — clean
- [x] Manual review of diff: `env.sample` (new, 10 lines), `.gitignore`
      (+4), `README.md` (+13)
