### PR TITLE
fix(pipeline): drop GHSA records whose latest version is unaffected

### DIFF
--- a/src/biibaa/adapters/_semver.py
+++ b/src/biibaa/adapters/_semver.py
@@ -1,0 +1,74 @@
+"""Minimal semver range matcher for GHSA `vulnerable_version_range` strings.
+
+The GHSA format is comma-separated comparisons (logical AND), e.g.:
+  "<= 0.23.0"
+  "< 1.2.3"
+  ">= 1.0.0, < 1.2.3"
+  "= 1.0.0"
+
+We strip pre-release and build metadata before comparison: that's a small
+loss of fidelity, but advisories almost always pin to released versions, and
+the alternative — pulling in a full semver lib — adds dependency weight for
+a single comparison.
+"""
+
+from __future__ import annotations
+
+
+def _parse_version(value: str) -> tuple[int, ...] | None:
+    v = value.lstrip("v").strip()
+    v = v.split("-", 1)[0].split("+", 1)[0]
+    if not v:
+        return None
+    parts = v.split(".")
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError:
+        return None
+
+
+def _cmp(a: tuple[int, ...], b: tuple[int, ...]) -> int:
+    n = max(len(a), len(b))
+    a2 = a + (0,) * (n - len(a))
+    b2 = b + (0,) * (n - len(b))
+    return (a2 > b2) - (a2 < b2)
+
+
+_OPS = ("<=", ">=", "<", ">", "=")
+
+
+def is_version_in_range(version: str, range_str: str) -> bool | None:
+    """Return True if `version` matches every clause in `range_str`.
+
+    Returns None when either input can't be parsed — callers should treat
+    None as "unknown" and keep the advisory rather than drop it.
+    """
+    target = _parse_version(version)
+    if target is None:
+        return None
+    for raw in range_str.split(","):
+        clause = raw.strip()
+        if not clause:
+            continue
+        op_match: str | None = None
+        for op in _OPS:
+            if clause.startswith(op):
+                op_match = op
+                break
+        if op_match is None:
+            return None
+        bound = _parse_version(clause[len(op_match) :].strip())
+        if bound is None:
+            return None
+        c = _cmp(target, bound)
+        if op_match == "<" and not c < 0:
+            return False
+        if op_match == "<=" and not c <= 0:
+            return False
+        if op_match == ">" and not c > 0:
+            return False
+        if op_match == ">=" and not c >= 0:
+            return False
+        if op_match == "=" and c != 0:
+            return False
+    return True

--- a/src/biibaa/adapters/npm_registry.py
+++ b/src/biibaa/adapters/npm_registry.py
@@ -1,0 +1,54 @@
+"""npm registry adapter — resolves the `latest` dist-tag for a package.
+
+Used to drop GHSA advisories whose affected range no longer covers the
+current published version: GHSA often leaves `first_patched_version` null
+even when the project moved past the affected range without backporting,
+and those advisories aren't a contribution opportunity.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+import httpx
+import structlog
+
+from biibaa.adapters._http import make_client
+
+log = structlog.get_logger(__name__)
+
+NPM_REGISTRY_URL = "https://registry.npmjs.org"
+
+
+class NpmRegistrySource:
+    name = "npm_registry"
+
+    def __init__(self, *, client: httpx.Client | None = None) -> None:
+        self._client = client or make_client(timeout=30.0)
+
+    def latest_version(self, *, package: str) -> str | None:
+        url = f"{NPM_REGISTRY_URL}/{quote(package, safe='@/')}"
+        try:
+            r = self._client.get(url, headers={"Accept": "application/json"})
+        except httpx.HTTPError as e:
+            log.warning("npm_registry.error", package=package, error=str(e))
+            return None
+        if r.status_code == 404:
+            return None
+        if r.status_code != 200:
+            log.warning(
+                "npm_registry.bad_status", package=package, status=r.status_code
+            )
+            return None
+        body = r.json()
+        latest = (body.get("dist-tags") or {}).get("latest")
+        return str(latest) if latest else None
+
+    def latest_versions(self, *, packages: list[str]) -> dict[str, str | None]:
+        out: dict[str, str | None] = {}
+        for p in packages:
+            out[p] = self.latest_version(package=p)
+        return out
+
+    def close(self) -> None:
+        self._client.close()

--- a/src/biibaa/pipeline/run.py
+++ b/src/biibaa/pipeline/run.py
@@ -20,11 +20,13 @@ from pathlib import Path
 
 import structlog
 
+from biibaa.adapters._semver import is_version_in_range
 from biibaa.adapters.dependents_factory import build_dependents_source
 from biibaa.adapters.e18e import E18eReplacementsSource
 from biibaa.adapters.github_advisories import GithubAdvisorySource
 from biibaa.adapters.github_repo import MONOREPO_SENTINEL, GithubRepoSource
 from biibaa.adapters.npm_downloads import NpmDownloadsSource
+from biibaa.adapters.npm_registry import NpmRegistrySource
 from biibaa.briefs.render import write_brief
 from biibaa.domain import Advisory, Brief, Opportunity, Project, Replacement
 from biibaa.ports.dependents import Dependent, DependentsSource
@@ -153,6 +155,47 @@ def _dedupe_advisories(advs: list[Advisory]) -> list[Advisory]:
     for a in advs:
         unique.setdefault(a.id, a)
     return list(unique.values())
+
+
+def _drop_outdated_unpatched(
+    advisories: list[Advisory], registry: NpmRegistrySource
+) -> list[Advisory]:
+    """Drop unpatched advisories whose affected range no longer covers `latest`.
+
+    GHSA frequently leaves `first_patched_version` null after a project moves
+    past the affected range without backporting a fix. Those records aren't
+    a contribution opportunity — users who upgrade are no longer exposed.
+    """
+    purls = sorted(
+        {a.project_purl for a in advisories if a.affected_versions}
+    )
+    names = [_project_name_from_purl(p) for p in purls]
+    latest_by_name = registry.latest_versions(packages=names)
+
+    kept: list[Advisory] = []
+    dropped = 0
+    for a in advisories:
+        if not a.affected_versions:
+            kept.append(a)
+            continue
+        latest = latest_by_name.get(_project_name_from_purl(a.project_purl))
+        if latest is None:
+            kept.append(a)
+            continue
+        in_range = is_version_in_range(latest, a.affected_versions)
+        if in_range is False:
+            log.info(
+                "advisory.dropped_outdated",
+                ghsa=a.id,
+                purl=a.project_purl,
+                latest=latest,
+                range=a.affected_versions,
+            )
+            dropped += 1
+            continue
+        kept.append(a)
+    log.info("advisory.outdated_filter", kept=len(kept), dropped=dropped)
+    return kept
 
 
 def _dedupe_replacements(reps: list[Replacement]) -> list[Replacement]:
@@ -288,6 +331,7 @@ def run(
 
     advisory_src = GithubAdvisorySource()
     downloads_src = NpmDownloadsSource()
+    registry_src = NpmRegistrySource() if ecosystem == "npm" else None
     e18e_src = E18eReplacementsSource() if include_replacements else None
     eco_src: DependentsSource | None = (
         build_dependents_source() if include_replacements else None
@@ -298,6 +342,8 @@ def run(
         advisory_src.fetch(ecosystem=ecosystem, limit=advisory_limit)
     )
     log.info("pipeline.advisories_fetched", count=len(advisories))
+    if registry_src:
+        advisories = _drop_outdated_unpatched(advisories, registry_src)
 
     replacements: list[Replacement] = []
     if e18e_src:
@@ -422,6 +468,8 @@ def run(
 
     advisory_src.close()
     downloads_src.close()
+    if registry_src:
+        registry_src.close()
     repo_src.close()
     if e18e_src:
         e18e_src.close()

--- a/tests/test_advisory_outdated_filter.py
+++ b/tests/test_advisory_outdated_filter.py
@@ -1,0 +1,59 @@
+"""Drop unpatched advisories whose affected range no longer covers `latest`."""
+
+from __future__ import annotations
+
+from biibaa.domain import Advisory
+from biibaa.pipeline.run import _drop_outdated_unpatched
+
+
+class _FakeRegistry:
+    def __init__(self, mapping: dict[str, str | None]) -> None:
+        self._mapping = mapping
+
+    def latest_versions(self, *, packages: list[str]) -> dict[str, str | None]:
+        return {p: self._mapping.get(p) for p in packages}
+
+
+def _adv(*, ghsa: str, name: str, affected: str | None) -> Advisory:
+    return Advisory(
+        id=ghsa,
+        project_purl=f"pkg:npm/{name}",
+        summary="t",
+        affected_versions=affected,
+    )
+
+
+def test_drops_when_latest_outside_affected_range() -> None:
+    advisories = [_adv(ghsa="GHSA-codex", name="@openai/codex", affected="<= 0.23.0")]
+    registry = _FakeRegistry({"@openai/codex": "0.125.0"})
+    out = _drop_outdated_unpatched(advisories, registry)  # type: ignore[arg-type]
+    assert out == []
+
+
+def test_keeps_when_latest_still_in_range() -> None:
+    advisories = [_adv(ghsa="GHSA-x", name="widget", affected=">= 0.0.1")]
+    registry = _FakeRegistry({"widget": "1.5.0"})
+    out = _drop_outdated_unpatched(advisories, registry)  # type: ignore[arg-type]
+    assert [a.id for a in out] == ["GHSA-x"]
+
+
+def test_keeps_when_latest_unknown() -> None:
+    """Don't drop on a registry blip."""
+    advisories = [_adv(ghsa="GHSA-y", name="ghost", affected="<= 0.1.0")]
+    registry = _FakeRegistry({"ghost": None})
+    out = _drop_outdated_unpatched(advisories, registry)  # type: ignore[arg-type]
+    assert [a.id for a in out] == ["GHSA-y"]
+
+
+def test_keeps_when_range_unparseable() -> None:
+    advisories = [_adv(ghsa="GHSA-z", name="weird", affected="completely-malformed")]
+    registry = _FakeRegistry({"weird": "1.0.0"})
+    out = _drop_outdated_unpatched(advisories, registry)  # type: ignore[arg-type]
+    assert [a.id for a in out] == ["GHSA-z"]
+
+
+def test_keeps_when_no_affected_range() -> None:
+    advisories = [_adv(ghsa="GHSA-w", name="unbounded", affected=None)]
+    registry = _FakeRegistry({"unbounded": "2.0.0"})
+    out = _drop_outdated_unpatched(advisories, registry)  # type: ignore[arg-type]
+    assert [a.id for a in out] == ["GHSA-w"]

--- a/tests/test_npm_registry.py
+++ b/tests/test_npm_registry.py
@@ -1,0 +1,46 @@
+"""npm registry adapter — record the dist-tags.latest contract."""
+
+from __future__ import annotations
+
+import httpx
+from pytest_httpx import HTTPXMock
+
+from biibaa.adapters.npm_registry import NpmRegistrySource
+
+
+def test_latest_version_reads_dist_tag(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://registry.npmjs.org/@openai/codex",
+        json={"dist-tags": {"latest": "0.125.0"}},
+    )
+    src = NpmRegistrySource(client=httpx.Client())
+    assert src.latest_version(package="@openai/codex") == "0.125.0"
+
+
+def test_latest_version_returns_none_on_404(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://registry.npmjs.org/missing-pkg",
+        status_code=404,
+    )
+    src = NpmRegistrySource(client=httpx.Client())
+    assert src.latest_version(package="missing-pkg") is None
+
+
+def test_latest_version_handles_missing_dist_tag(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://registry.npmjs.org/empty",
+        json={"versions": {}},
+    )
+    src = NpmRegistrySource(client=httpx.Client())
+    assert src.latest_version(package="empty") is None
+
+
+def test_latest_versions_iterates(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        url="https://registry.npmjs.org/a", json={"dist-tags": {"latest": "1.0.0"}}
+    )
+    httpx_mock.add_response(
+        url="https://registry.npmjs.org/b", json={"dist-tags": {"latest": "2.0.0"}}
+    )
+    src = NpmRegistrySource(client=httpx.Client())
+    assert src.latest_versions(packages=["a", "b"]) == {"a": "1.0.0", "b": "2.0.0"}

--- a/tests/test_semver.py
+++ b/tests/test_semver.py
@@ -1,0 +1,44 @@
+"""Cover the GHSA range strings the pipeline relies on."""
+
+from __future__ import annotations
+
+from biibaa.adapters._semver import is_version_in_range
+
+
+def test_lte_matches_within_range() -> None:
+    assert is_version_in_range("0.23.0", "<= 0.23.0") is True
+    assert is_version_in_range("0.22.5", "<= 0.23.0") is True
+
+
+def test_lte_excludes_newer_version() -> None:
+    # The motivating case: @openai/codex affected `<= 0.23.0`, latest 0.125.0.
+    assert is_version_in_range("0.125.0", "<= 0.23.0") is False
+
+
+def test_compound_range_and_semantics() -> None:
+    assert is_version_in_range("1.1.0", ">= 1.0.0, < 1.2.3") is True
+    assert is_version_in_range("1.2.3", ">= 1.0.0, < 1.2.3") is False
+    assert is_version_in_range("0.9.9", ">= 1.0.0, < 1.2.3") is False
+
+
+def test_open_range_matches_everything() -> None:
+    assert is_version_in_range("9.9.9", ">= 0.0.1") is True
+
+
+def test_unparseable_range_returns_none() -> None:
+    assert is_version_in_range("1.0.0", "garbage") is None
+
+
+def test_unparseable_version_returns_none() -> None:
+    assert is_version_in_range("not-a-version", "<= 1.0.0") is None
+
+
+def test_v_prefix_and_minor_only() -> None:
+    assert is_version_in_range("v1.2", "<= 1.2.0") is True
+    assert is_version_in_range("1.2", "< 1.2.0") is False
+
+
+def test_prerelease_metadata_stripped() -> None:
+    # Pre-release tags are dropped before comparison; advisories nearly
+    # always pin to released versions, so this trade-off is acceptable.
+    assert is_version_in_range("1.0.0-beta.1", "<= 1.0.0") is True


### PR DESCRIPTION
## Summary
- GHSA leaves `first_patched_version: null` on advisories where upstream simply moved past the affected range without backporting, so the unpatched-only fetch path was emitting briefs framed as "no upstream patch — contribute one" for packages that are already safe to upgrade. Canonical example: `data/briefs/openai__codex/2026-04-27.md` (GHSA-xrxf-jgv3-qmrm, affected `<= 0.23.0`, latest 0.125.0).
- New `NpmRegistrySource` reads `dist-tags.latest` from `registry.npmjs.org`. New `_semver.is_version_in_range` parses GHSA's comma-separated comparison format (`<= X`, `>= X, < Y`, etc.).
- New `_drop_outdated_unpatched()` step runs right after `advisory_src.fetch()`. Drops the advisory only when the latest version is provably outside the affected range; unknown latest or unparseable range stays kept so a registry hiccup can't silently lose real findings.

## How it works
1. Pipeline pulls advisories as before.
2. For each advisory's package, look up `registry.npmjs.org/<pkg>` → `dist-tags.latest`.
3. Run the latest version against the advisory's `vulnerable_version_range`.
4. If clearly unaffected → drop with a structured log line. Else → keep.

## Test plan
- [x] `pytest tests/test_semver.py` — 8 cases covering `<=`, compound `>= X, < Y`, open ranges, malformed input, `v` prefix, pre-release stripping
- [x] `pytest tests/test_advisory_outdated_filter.py` — 5 cases covering drop-on-outdated, keep-on-in-range, keep-on-unknown-latest, keep-on-unparseable, keep-on-no-range
- [x] `pytest tests/test_npm_registry.py` — 4 cases covering `dist-tags.latest`, 404, missing tag, bulk
- [x] Full suite: 99 passed, 1 skipped
- [x] `ruff check src tests` — clean
