### PR TITLE
fix(fanout): parse pnpm-lock.yaml to filter monorepo transitives

### DIFF
--- a/src/biibaa/adapters/github_repo.py
+++ b/src/biibaa/adapters/github_repo.py
@@ -25,6 +25,7 @@ from datetime import datetime
 
 import httpx
 import structlog
+import yaml
 
 from biibaa.adapters._http import make_client
 
@@ -32,10 +33,22 @@ log = structlog.get_logger(__name__)
 
 GRAPHQL_URL = "https://api.github.com/graphql"
 
-# Sentinel returned by fetch_direct_deps for monorepo roots — enumerating
-# every workspace's package.json multiplies API cost and risks dropping
-# legit dependents, so callers treat this as "verified, don't filter".
+# Sentinel returned by fetch_direct_deps for monorepo roots when no
+# lockfile is available — enumerating every workspace's package.json
+# multiplies API cost and risks dropping legit dependents, so callers
+# treat this as "verified, don't filter". Preferred path is to parse
+# `pnpm-lock.yaml` instead, which lists direct deps for every workspace
+# in a single HTTP fetch.
 MONOREPO_SENTINEL = "*MONOREPO*"
+
+# Workspace dependency sections in `pnpm-lock.yaml` `importers.<path>` whose
+# keys are direct deps of that workspace's `package.json`.
+_PNPM_DEP_SECTIONS: tuple[str, ...] = (
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+)
 
 # Bench libraries we trust as a signal that the repo has runnable benchmarks.
 # Conservative on purpose — vitest/jest are bench-capable but their bench
@@ -115,6 +128,10 @@ class GithubRepoSource:
         # Caches the parsed package.json so fetch_direct_deps and bench_info
         # share a single HTTP round-trip per repo. None = fetch/parse failed.
         self._pkg_cache: dict[tuple[str, str], dict | None] = {}
+        # Caches the union of direct-dep names across all workspaces parsed
+        # from `pnpm-lock.yaml`. None = fetch or parse failed (caller falls
+        # back to MONOREPO_SENTINEL).
+        self._lockfile_cache: dict[tuple[str, str], set[str] | None] = {}
 
     def _headers(self) -> dict[str, str]:
         h = {"Accept": "application/vnd.github+json"}
@@ -203,15 +220,67 @@ class GithubRepoSource:
         self._pkg_cache[parsed] = payload
         return payload
 
+    def _fetch_pnpm_lockfile_deps(self, *, repo_url: str) -> set[str] | None:
+        """Parse `pnpm-lock.yaml` and return the union of direct-dep names
+        across every workspace's `importers.<path>` entry.
+
+        pnpm's `importers` map is keyed by workspace path; under each entry
+        the `dependencies` / `devDependencies` / `optionalDependencies` /
+        `peerDependencies` maps mirror the workspace's `package.json` —
+        their keys are exactly the directly-declared deps. Transitive deps
+        live under the separate top-level `packages` map and are excluded.
+
+        Returns `None` if the lockfile is missing, unparseable, or empty.
+        """
+        parsed = _parse_repo_url(repo_url)
+        if not parsed:
+            return None
+        if parsed in self._lockfile_cache:
+            return self._lockfile_cache[parsed]
+        owner, name = parsed
+        url = f"https://raw.githubusercontent.com/{owner}/{name}/HEAD/pnpm-lock.yaml"
+        try:
+            r = self._client.get(url, headers=self._headers())
+            r.raise_for_status()
+            doc = yaml.safe_load(r.text)
+        except (httpx.HTTPError, yaml.YAMLError) as e:
+            log.warning("github_repo.fetch_lockfile_failed", repo=repo_url, error=str(e))
+            self._lockfile_cache[parsed] = None
+            return None
+        if not isinstance(doc, dict):
+            self._lockfile_cache[parsed] = None
+            return None
+        importers = doc.get("importers")
+        if not isinstance(importers, dict):
+            self._lockfile_cache[parsed] = None
+            return None
+        names: set[str] = set()
+        for imp in importers.values():
+            if not isinstance(imp, dict):
+                continue
+            for section in _PNPM_DEP_SECTIONS:
+                m = imp.get(section)
+                if isinstance(m, dict):
+                    names |= set(m.keys())
+        if not names:
+            self._lockfile_cache[parsed] = None
+            return None
+        self._lockfile_cache[parsed] = names
+        return names
+
     def fetch_direct_deps(self, *, repo_url: str) -> set[str] | None:
         """Return the set of names listed in `dependencies`+`devDependencies`
         of the repo's HEAD `package.json`.
 
         Returns `None` on any failure (parse error, 404, network error) so
         callers can treat the result as "unknown — don't filter". For monorepo
-        roots (a non-empty `workspaces` field), returns `{MONOREPO_SENTINEL}`
-        because enumerating each workspace's package.json multiplies API cost
-        and risks dropping legit dependents.
+        roots (a non-empty `workspaces` field), tries `pnpm-lock.yaml` first
+        — its `importers` map gives every workspace's direct deps in one
+        HTTP fetch, which lets the fan-out filter drop transitive-only hits
+        from lockfile-derived SBOMs (e.g. an iOS-tooling dep four levels deep
+        under Expo). Falls back to `{MONOREPO_SENTINEL}` when the lockfile
+        is absent or unparseable so callers still treat the repo as
+        "verified, don't filter".
         """
         payload = self._fetch_pkg_json(repo_url=repo_url)
         if payload is None:
@@ -219,14 +288,18 @@ class GithubRepoSource:
 
         # Monorepo detection: `workspaces` may be an array or an object with
         # a `packages` array (Yarn/Lerna style). Either form means this is a
-        # monorepo root — give benefit of doubt and verify-as-passed.
+        # monorepo root.
         ws = payload.get("workspaces")
-        if isinstance(ws, list) and ws:
+        is_monorepo = (isinstance(ws, list) and bool(ws)) or (
+            isinstance(ws, dict)
+            and isinstance(ws.get("packages"), list)
+            and bool(ws["packages"])
+        )
+        if is_monorepo:
+            lockfile_deps = self._fetch_pnpm_lockfile_deps(repo_url=repo_url)
+            if lockfile_deps is not None:
+                return lockfile_deps
             return {MONOREPO_SENTINEL}
-        if isinstance(ws, dict):
-            pkgs = ws.get("packages")
-            if isinstance(pkgs, list) and pkgs:
-                return {MONOREPO_SENTINEL}
 
         deps = payload.get("dependencies")
         dev_deps = payload.get("devDependencies")

--- a/tests/test_direct_deps_filter.py
+++ b/tests/test_direct_deps_filter.py
@@ -50,7 +50,7 @@ def test_fetch_direct_deps_returns_empty_set_when_manifest_has_no_deps(
     assert got == set()
 
 
-def test_fetch_direct_deps_returns_monorepo_sentinel_for_array_workspaces(
+def test_fetch_direct_deps_returns_monorepo_sentinel_for_array_workspaces_without_lockfile(
     httpx_mock: HTTPXMock,
 ) -> None:
     httpx_mock.add_response(
@@ -63,12 +63,17 @@ def test_fetch_direct_deps_returns_monorepo_sentinel_for_array_workspaces(
             "dependencies": {"lodash": "^4.0.0"},
         },
     )
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/mono/repo/HEAD/pnpm-lock.yaml",
+        method="GET",
+        status_code=404,
+    )
     src = GithubRepoSource(token="x", client=httpx.Client())
     got = src.fetch_direct_deps(repo_url="https://github.com/mono/repo")
     assert got == {MONOREPO_SENTINEL}
 
 
-def test_fetch_direct_deps_returns_monorepo_sentinel_for_object_workspaces(
+def test_fetch_direct_deps_returns_monorepo_sentinel_for_object_workspaces_without_lockfile(
     httpx_mock: HTTPXMock,
 ) -> None:
     httpx_mock.add_response(
@@ -81,6 +86,93 @@ def test_fetch_direct_deps_returns_monorepo_sentinel_for_object_workspaces(
                 "nohoist": ["**/foo"],
             },
         },
+    )
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/mono/repo/HEAD/pnpm-lock.yaml",
+        method="GET",
+        status_code=404,
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    got = src.fetch_direct_deps(repo_url="https://github.com/mono/repo")
+    assert got == {MONOREPO_SENTINEL}
+
+
+def test_fetch_direct_deps_uses_pnpm_lockfile_for_monorepo(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Monorepo + pnpm-lock.yaml present → returns union of importer direct
+    deps so transitive-only matches (e.g. stream-buffers under expo) are
+    filtered out instead of letting the sentinel bypass the check."""
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/mono/repo/HEAD/package.json",
+        method="GET",
+        json={
+            "name": "mono",
+            "private": True,
+            "workspaces": {"packages": ["packages/*"]},
+        },
+    )
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/mono/repo/HEAD/pnpm-lock.yaml",
+        method="GET",
+        text=(
+            "lockfileVersion: '6.0'\n"
+            "importers:\n"
+            "  .:\n"
+            "    devDependencies:\n"
+            "      eslint:\n"
+            "        specifier: ^8\n"
+            "        version: 8.57.0\n"
+            "  packages/oauth-client-expo:\n"
+            "    peerDependencies:\n"
+            "      expo:\n"
+            "        specifier: '*'\n"
+            "        version: 50.0.0\n"
+            "    dependencies:\n"
+            "      jose:\n"
+            "        specifier: ^5\n"
+            "        version: 5.2.0\n"
+            "packages:\n"
+            "  /stream-buffers@3.0.2:\n"
+            "    resolution: {integrity: sha512-fake}\n"
+        ),
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    got = src.fetch_direct_deps(repo_url="https://github.com/mono/repo")
+    assert got == {"eslint", "expo", "jose"}
+    assert got is not None and "stream-buffers" not in got
+
+
+def test_fetch_pnpm_lockfile_falls_back_when_yaml_invalid(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/mono/repo/HEAD/package.json",
+        method="GET",
+        json={"name": "mono", "workspaces": ["packages/*"]},
+    )
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/mono/repo/HEAD/pnpm-lock.yaml",
+        method="GET",
+        text="not: valid: yaml: : :",
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    got = src.fetch_direct_deps(repo_url="https://github.com/mono/repo")
+    assert got == {MONOREPO_SENTINEL}
+
+
+def test_fetch_pnpm_lockfile_falls_back_when_no_importers(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/mono/repo/HEAD/package.json",
+        method="GET",
+        json={"name": "mono", "workspaces": ["packages/*"]},
+    )
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/mono/repo/HEAD/pnpm-lock.yaml",
+        method="GET",
+        text="lockfileVersion: '6.0'\n",
     )
     src = GithubRepoSource(token="x", client=httpx.Client())
     got = src.fetch_direct_deps(repo_url="https://github.com/mono/repo")
@@ -251,7 +343,9 @@ def test_filter_keeps_candidate_when_verification_returns_none(
     assert [d.name for _, d in out] == ["private-pkg"]
 
 
-def test_filter_keeps_candidate_for_monorepo_root(httpx_mock: HTTPXMock) -> None:
+def test_filter_keeps_candidate_for_monorepo_root_without_lockfile(
+    httpx_mock: HTTPXMock,
+) -> None:
     httpx_mock.add_response(
         url="https://raw.githubusercontent.com/big/mono/HEAD/package.json",
         method="GET",
@@ -261,6 +355,11 @@ def test_filter_keeps_candidate_for_monorepo_root(httpx_mock: HTTPXMock) -> None
             "workspaces": ["packages/*"],
             "devDependencies": {"jest": "^29"},
         },
+    )
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/big/mono/HEAD/pnpm-lock.yaml",
+        method="GET",
+        status_code=404,
     )
     eco = _StubEcoSrc(
         [_dep("mono", "https://github.com/big/mono")]
@@ -276,6 +375,55 @@ def test_filter_keeps_candidate_for_monorepo_root(httpx_mock: HTTPXMock) -> None
         repo_src=repo_src,
     )
     assert [d.name for _, d in out] == ["mono"]
+
+
+def test_filter_drops_transitive_only_dep_in_monorepo_with_pnpm_lock(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """The atproto/stream-buffers regression: a pnpm monorepo where the
+    flagged package only appears via a 4-deep transitive chain. Lockfile
+    parsing surfaces the real direct deps so the candidate is dropped."""
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/bsky/atproto/HEAD/package.json",
+        method="GET",
+        json={
+            "name": "atp",
+            "private": True,
+            "workspaces": {"packages": ["packages/*"]},
+        },
+    )
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/bsky/atproto/HEAD/pnpm-lock.yaml",
+        method="GET",
+        text=(
+            "lockfileVersion: '6.0'\n"
+            "importers:\n"
+            "  .:\n"
+            "    devDependencies:\n"
+            "      eslint:\n"
+            "        specifier: ^8\n"
+            "        version: 8.57.0\n"
+            "  packages/oauth-client-expo:\n"
+            "    peerDependencies:\n"
+            "      expo:\n"
+            "        specifier: '*'\n"
+            "        version: 50.0.0\n"
+        ),
+    )
+    eco = _StubEcoSrc(
+        [_dep("atproto", "https://github.com/bsky/atproto")]
+    )
+    downloads = _StubDownloadsSrc({"stream-buffers": 12_000_000})
+    repo_src = _make_repo_src(httpx.Client())
+    out = _fan_out_dependents(
+        replacements=[_replacement("stream-buffers")],
+        eco_src=eco,  # type: ignore[arg-type]
+        downloads_src=downloads,  # type: ignore[arg-type]
+        fanout_top_n=10,
+        dependents_per_replacement=5,
+        repo_src=repo_src,
+    )
+    assert out == []
 
 
 def test_filter_disabled_when_repo_src_is_none() -> None:


### PR DESCRIPTION
## Summary

Fix false-positive briefs where a flagged package only reaches a monorepo through a deep transitive chain.

`fetch_direct_deps` previously short-circuited every monorepo root to `MONOREPO_SENTINEL`, which the fan-out filter treats as "verified, don't filter". Combined with OSO's `sboms_v0` (lockfile-derived, full transitive tree), this let purely-transitive matches leak through as briefs — most visibly `stream-buffers` and `scmp` on `bluesky-social/atproto`, where they sit four levels deep under `@expo/cli` iOS plist tooling.

## How it works

When a monorepo root is detected, fetch `pnpm-lock.yaml` from `HEAD` and union the dep names declared across every `importers.<path>` entry (`dependencies` / `devDependencies` / `optionalDependencies` / `peerDependencies`). Those keys mirror each workspace's own `package.json`, so any package not in the union is purely transitive and gets filtered out. One extra HTTP per monorepo, no per-workspace fan-out. Falls back to `MONOREPO_SENTINEL` when the lockfile is missing or unparseable.

## Test plan

- [x] `uv run pytest -x` (91 passing, 4 new)
- [x] `uv run ruff check`, `uv run mypy src/biibaa/adapters/github_repo.py` clean
- [x] Real-data smoke check against `bluesky-social/atproto`: parser yields 207 direct deps, with `stream-buffers`, `scmp`, `bplist-creator`, `simple-plist` all absent and `expo` correctly present
- [ ] Manual: re-run the brief pipeline and confirm the atproto brief no longer surfaces `stream-buffers`/`scmp`

## Notes

- npm and yarn lockfiles are not handled here — atproto and most modern monorepos use pnpm. Adding `package-lock.json` and `yarn.lock` parsing is straightforward to layer on later if needed.
