### PR TITLE
feat(brief): group brief output by ecosystem subdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ uv sync
 uv run biibaa run --top 20
 ```
 
-Briefs land in `data/briefs/<project>/<yyyy-mm-dd>.md`.
+Briefs land in `data/briefs/<ecosystem>/<project>/<yyyy-mm-dd>.md` (e.g. `data/briefs/npm/react__react/2026-04-27.md`).
 
 ## Configuration
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -105,7 +105,7 @@ sources → ingest (raw landing) → normalize (canonical model) → score → b
 2. **Normalize** — SQLMesh staging models read raw Parquet via DuckDB's `read_parquet`, decode into typed staging tables; intermediate models apply source precedence (§3.2) and dedupe. Time-partitioned raw inputs map to `INCREMENTAL_BY_TIME_RANGE` models keyed on the ingest date.
 3. **Fan-out** — for each flagged package, enumerate top-K dependents via npm browse (and ecosyste.ms when extending) to expand the candidate set.
 4. **Score** — apply heuristics (§6). Materialize `opportunities` table.
-5. **Brief** — pick top-N projects by aggregate score; render Markdown briefs to `data/briefs/<project>/<yyyy-mm-dd>.md`.
+5. **Brief** — pick top-N projects by aggregate score; render Markdown briefs to `data/briefs/<ecosystem>/<project>/<yyyy-mm-dd>.md`.
 
 Each step is idempotent and replayable from raw.
 
@@ -245,7 +245,7 @@ This is a deliberate departure from the TypeScript/Effect-TS preference in `arch
 | **Marts** | SQLMesh `FULL` or `INCREMENTAL` models | `projects`, `advisories`, `replacements`, `dependents`, `opportunities` |
 | **Score** | SQLMesh SQL + macros | Apply popularity + severity + effort heuristics; materialize `opportunities` |
 | **Audits** | SQLMesh audits | `not_null`, `unique_values`, `relationships`, custom (e.g. `score_in_range`) |
-| **Brief** | Python + Jinja2 | Read `opportunities` from DuckDB; render Markdown to `data/briefs/<project>/<date>.md` |
+| **Brief** | Python + Jinja2 | Read `opportunities` from DuckDB; render Markdown to `data/briefs/<ecosystem>/<project>/<date>.md` |
 | **CLI** | Python (Typer) | `biibaa ingest <source>`, `biibaa run`, `biibaa brief`, `biibaa show <project>` |
 
 ### 9.2 Hexagonal split (Python)

--- a/src/biibaa/pipeline/run.py
+++ b/src/biibaa/pipeline/run.py
@@ -418,7 +418,9 @@ def run(
 
     paths: list[Path] = []
     for brief in top:
-        paths.append(write_brief(brief, output_dir / brief.slug))
+        paths.append(
+            write_brief(brief, output_dir / brief.project.ecosystem / brief.slug)
+        )
 
     advisory_src.close()
     downloads_src.close()


### PR DESCRIPTION
## Summary

Group brief output by ecosystem so multi-ecosystem runs don't collide and downstream SSGs can build per-language listings without parsing every frontmatter.

Briefs now land at `data/briefs/<ecosystem>/<slug>/<date>.md` (e.g. `data/briefs/npm/react__react/2026-04-27.md`). The pipeline reads `Project.ecosystem` (`npm` / `pypi` / etc.) and inserts it as the parent directory.

## Migration

All 476 existing briefs locally were `npm` and have been moved to `data/briefs/npm/*` on this branch. Anyone with a checkout that has `data/briefs/` populated should run the same move:

```sh
cd data/briefs && mkdir -p npm && \
  find . -mindepth 1 -maxdepth 1 -type d ! -name npm -exec mv {} npm/ \;
```

`data/` is gitignored, so the move is local-only and doesn't show up in the diff.

## Test plan

- [x] `uv run pytest -x` (87 passing)
- [x] `uv run ruff check`, `uv run mypy src/biibaa/pipeline/run.py` (one pre-existing error at line 138, unrelated to this change)
- [x] README + SPEC updated to reflect new path layout
- [ ] Manual: re-run the brief pipeline and confirm new briefs land under `data/briefs/npm/`
