### PR TITLE
feat(cli): tunable fan-out flags + pyoso query timeout + dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Workspace temp
 .tmp/
+.claude/worktrees/
 
 # Python
 __pycache__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "typer>=0.12",
     "structlog>=24.1",
     "pyyaml>=6.0",
+    "python-dotenv>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/biibaa/adapters/pyoso_dependents.py
+++ b/src/biibaa/adapters/pyoso_dependents.py
@@ -14,6 +14,7 @@ because pyoso's `to_pandas` takes raw SQL with no parameterization.
 from __future__ import annotations
 
 import re
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
 import structlog
 
@@ -64,9 +65,12 @@ class PyosoSource:
         client: Client | None = None,
         min_stars: int = 10,
         breaker: CircuitBreaker[list[Dependent]] | None = None,
+        query_timeout_seconds: float = 30.0,
     ) -> None:
         self._client = client or Client(api_key=api_key)
         self._min_stars = min_stars
+        self._timeout = query_timeout_seconds
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="pyoso")
         self._breaker = breaker or CircuitBreaker[list[Dependent]](
             name="pyoso",
             failure_threshold=3,
@@ -86,8 +90,12 @@ class PyosoSource:
         sql = _QUERY_TEMPLATE.format(
             package=package, min_stars=self._min_stars, top_k=top_k
         )
+        future = self._executor.submit(self._client.to_pandas, sql)
         try:
-            df = self._client.to_pandas(sql)
+            df = future.result(timeout=self._timeout)
+        except FuturesTimeoutError:
+            log.warning("pyoso.query_timeout", package=package, timeout=self._timeout)
+            return []
         except Exception as e:
             log.warning("pyoso.query_error", package=package, error=str(e))
             return []
@@ -109,8 +117,7 @@ class PyosoSource:
         return out
 
     def close(self) -> None:
-        # pyoso Client has no explicit close.
-        pass
+        self._executor.shutdown(wait=False, cancel_futures=True)
 
 
 def build_query(*, package: str, min_stars: int, top_k: int) -> str:

--- a/src/biibaa/cli/main.py
+++ b/src/biibaa/cli/main.py
@@ -5,8 +5,11 @@ from pathlib import Path
 
 import structlog
 import typer
+from dotenv import load_dotenv
 
 from biibaa.pipeline.run import run as run_pipeline
+
+load_dotenv()
 
 app = typer.Typer(help="biibaa — open source improvement opportunity tracker")
 
@@ -34,6 +37,15 @@ def run(
     advisory_limit: int = typer.Option(
         400, "--advisory-limit", help="Max advisories to ingest"
     ),
+    fanout_top_n: int = typer.Option(
+        40, "--fanout-top-n", help="Number of e18e replacements to fan out from"
+    ),
+    dependents_per_replacement: int = typer.Option(
+        5, "--dependents-per-replacement", help="Top-K dependents per replacement"
+    ),
+    min_weekly_downloads: int = typer.Option(
+        50_000, "--min-weekly-downloads", help="Drop projects below this floor"
+    ),
     verbose: bool = typer.Option(False, "-v", "--verbose"),
 ) -> None:
     """Ingest advisories, score, and render top-N improvement briefs."""
@@ -43,6 +55,9 @@ def run(
         top_n=top_n,
         ecosystem=ecosystem,
         advisory_limit=advisory_limit,
+        fanout_top_n=fanout_top_n,
+        dependents_per_replacement=dependents_per_replacement,
+        min_weekly_downloads=min_weekly_downloads,
     )
     typer.echo(f"Generated {len(paths)} briefs:")
     for p in paths:

--- a/uv.lock
+++ b/uv.lock
@@ -55,6 +55,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "structlog" },
     { name = "typer" },
@@ -80,6 +81,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyoso", marker = "extra == 'pyoso'", specifier = ">=0.9" },
+    { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "structlog", specifier = ">=24.1" },
     { name = "typer", specifier = ">=0.12" },
@@ -754,6 +756,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Surface three pipeline knobs as `run` CLI flags: `--fanout-top-n`, `--dependents-per-replacement`, `--min-weekly-downloads`. Lets operators tighten or widen fan-out without editing source.
- Load `.env` automatically at CLI startup (`python-dotenv`) so `PYOSO_API_KEY` and friends can live in `.env`.
- Pyoso adapter: run `to_pandas` on a single-thread `ThreadPoolExecutor` with a configurable timeout (30s default). On timeout we log `pyoso.query_timeout` and return `[]` instead of hanging the pipeline. `close()` shuts the executor down.
- Repo hygiene: ignore `.claude/worktrees/` so future agent worktrees don't get accidentally staged as gitlinks.

## Test plan
- [ ] `uv run biibaa run --help` shows the three new flags with the expected defaults.
- [ ] `uv run biibaa run --fanout-top-n 5 --dependents-per-replacement 2 --min-weekly-downloads 100000` completes a small run end-to-end.
- [ ] With a `.env` containing `PYOSO_API_KEY=…`, `uv run biibaa run` picks it up without an explicit export.
- [ ] Force a pyoso slow-path (or set `query_timeout_seconds` low in a unit test) and confirm the timeout branch logs and returns `[]`.
- [ ] `git status` after a fresh `claude` worktree session no longer surfaces `.claude/worktrees/*` as untracked or staged.
