### PR TITLE
chore(oso): add OSO BigQuery scoping doc + POC scripts

### DIFF
--- a/docs/integrations/oso-bigquery.md
+++ b/docs/integrations/oso-bigquery.md
@@ -1,0 +1,315 @@
+# OSO BigQuery Integration Scoping
+
+**Status**: Draft / Pre-implementation  
+**Date**: 2026-04-26  
+**Addresses**: ecosyste.ms 500-error gap on high-popularity npm packages
+
+---
+
+## Background
+
+biibaa's current fan-out step enumerates top dependents of a flagged npm package via
+ecosyste.ms, which reliably 500s on the most popular packages (debug, axios, moment,
+lodash, chalk, fs-extra, etc.). These are exactly the high-signal cases: packages with
+millions of weekly downloads have the largest blast radius when vulnerabilities are
+unpatched. This doc scopes a replacement using the
+[OSO (Open Source Observer)](https://www.opensource.observer/) BigQuery dataset.
+
+---
+
+## OSO BigQuery Access Model
+
+OSO publishes its production pipeline output through BigQuery Analytics Hub as a
+**linked dataset** — you subscribe once through the GCP console and the data stays
+live in your own GCP project namespace. The subscription is **free to access**; you
+pay only standard BigQuery on-demand query costs against bytes scanned (first 1 TB/mo
+is free under GCP's free tier).
+
+Access path:
+
+1. Sign up for GCP at https://cloud.google.com/ (free tier is sufficient for biibaa's
+   query volume).
+2. Subscribe to the OSO production dataset via the Analytics Hub listing:
+   https://console.cloud.google.com/bigquery/analytics-hub/exchanges/projects/87806073973/locations/us/dataExchanges/open_source_observer_190181416ae/listings/oso_data_pipeline_190187c6517
+3. Name the linked dataset `oso_production` inside your GCP project (call it
+   `<YOUR_GCP_PROJECT>`).
+4. All tables are then addressable as `` `<YOUR_GCP_PROJECT>.oso_production.<table>` ``.
+
+**License**: CC BY-SA 4.0.  
+**Auth for Python**: service-account JSON key (or Application Default Credentials via
+`gcloud auth application-default login`). The `google-cloud-bigquery` PyPI package is
+the standard client. No custom token exchange — standard GCP IAM.
+
+Install:
+
+```sh
+pip install google-cloud-bigquery pandas pyarrow
+```
+
+Set credentials:
+
+```sh
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+# or use ADC:
+gcloud auth application-default login
+```
+
+---
+
+## Relevant OSO Tables
+
+### 1. `sboms_v0` — Dependents Fan-Out (replaces ecosyste.ms)
+
+**Full identifier**: `` `<YOUR_GCP_PROJECT>.oso_production.sboms_v0` ``  
+**biibaa concern**: dependents fan-out (§5 pipeline, "Fan-out" step; §8.1 `dependents` table)
+
+This is the most valuable table for biibaa. OSO ingests Software Bill of Materials
+(SBOM) files from GitHub repos tracked in `oss-directory` and joins them against the
+`deps.dev` package graph. The result is a flat reverse-dependency table: for each
+`(dependent_repo, package)` pair, one row.
+
+| Column | Type | Notes |
+|---|---|---|
+| `dependent_artifact_id` | STRING | OSO-internal hash ID for the dependent repo |
+| `dependent_artifact_source` | STRING | Always `"GITHUB"` for npm-tracked repos |
+| `dependent_artifact_namespace` | STRING | GitHub org (e.g. `"facebook"`) |
+| `dependent_artifact_name` | STRING | GitHub repo name (e.g. `"react"`) |
+| `package_artifact_id` | STRING | OSO-internal hash ID for the package |
+| `package_artifact_source` | STRING | e.g. `"NPM"` |
+| `package_artifact_namespace` | STRING | npm scope, empty for unscoped packages |
+| `package_artifact_name` | STRING | npm package name (e.g. `"lodash"`) |
+
+The underlying lineage is:
+
+```
+stg_deps_dev__packages   (from bigquery-public-data.deps_dev_v1.PackageVersionToProject)
+    → int_packages_from_deps_dev
+    → int_packages__current_maintainer_only
+stg_ossd__current_sbom   (SBOM files from GitHub repos in oss-directory)
+    → int_sbom_from_ossd
+    → int_sbom__latest_snapshot
+→ int_sbom_to_packages
+→ sboms_v0
+```
+
+**Scope caveat**: `sboms_v0` only covers repos that are (a) in OSO's `oss-directory`
+and (b) have published a machine-readable SBOM (GitHub's dependency graph / a committed
+`package.json`). This is not all of npm. However, it covers the curated high-quality
+OSS universe that biibaa most wants to target, and it does not 500 on popular packages.
+
+**Representative query** — top 20 GitHub repos depending on `lodash`:
+
+```sql
+SELECT
+  dependent_artifact_namespace,
+  dependent_artifact_name,
+  CONCAT('https://github.com/', dependent_artifact_namespace, '/', dependent_artifact_name)
+    AS repo_url
+FROM `<YOUR_GCP_PROJECT>.oso_production.sboms_v0`
+WHERE
+  package_artifact_source = 'NPM'
+  AND package_artifact_name = 'lodash'
+LIMIT 20
+```
+
+---
+
+### 2. `repositories_v0` — Repo Activity Signals (confidence scoring)
+
+**Full identifier**: `` `<YOUR_GCP_PROJECT>.oso_production.repositories_v0` ``  
+**biibaa concern**: scoring disqualifiers (§6.4) — archived flag, last push date,
+star count; supplements GitHub REST calls with pre-fetched bulk data
+
+| Column | Type | Notes |
+|---|---|---|
+| `artifact_id` | STRING | OSO hash ID, joinable to `sboms_v0.dependent_artifact_id` |
+| `artifact_source` | STRING | `"GITHUB"` |
+| `artifact_namespace` | STRING | GitHub org |
+| `artifact_name` | STRING | GitHub repo name |
+| `artifact_url` | STRING | Full HTTPS URL |
+| `is_fork` | BOOLEAN | Fork flag |
+| `star_count` | INT64 | Star count |
+| `watcher_count` | INT64 | Watcher count |
+| `fork_count` | INT64 | Fork count |
+| `license_name` | STRING | License (e.g. `"MIT"`) |
+| `language` | STRING | Primary language |
+| `created_at` | TIMESTAMP | Repo creation time |
+| `updated_at` | TIMESTAMP | Last push / update time |
+
+Join pattern to enrich dependents with repo signals:
+
+```sql
+SELECT
+  s.dependent_artifact_namespace AS org,
+  s.dependent_artifact_name     AS repo,
+  r.star_count,
+  r.updated_at,
+  r.is_fork,
+  DATE_DIFF(CURRENT_DATE(), DATE(r.updated_at), DAY) AS days_since_push
+FROM `<YOUR_GCP_PROJECT>.oso_production.sboms_v0` AS s
+JOIN `<YOUR_GCP_PROJECT>.oso_production.repositories_v0` AS r
+  ON s.dependent_artifact_id = r.artifact_id
+WHERE
+  s.package_artifact_source = 'NPM'
+  AND s.package_artifact_name = 'lodash'
+  AND r.updated_at > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 730 DAY)  -- active in 2yr
+  AND r.is_fork = FALSE
+ORDER BY r.star_count DESC
+LIMIT 50
+```
+
+This single query replaces: (1) ecosyste.ms fan-out call, (2) GitHub REST calls for
+`archived` / `pushed_at` / `stargazers_count` per repo.
+
+---
+
+### 3. `projects_v1` + `artifacts_by_project_v1` — Candidate Seeding
+
+**Full identifiers**:
+- `` `<YOUR_GCP_PROJECT>.oso_production.projects_v1` ``
+- `` `<YOUR_GCP_PROJECT>.oso_production.artifacts_by_project_v1` ``
+
+**biibaa concern**: SPEC §11 open question #1 — "seed with watchlist (top 1k npm by
+dependents) and expand via fan-out". OSO's `oss-directory` tracks ~7 000 curated OSS
+projects. These are the repos with the highest community attention and the most likely
+targets for biibaa briefs.
+
+| Table | Key columns |
+|---|---|
+| `projects_v1` | `project_id`, `project_source`, `project_name`, `display_name`, `description` |
+| `artifacts_by_project_v1` | `project_id`, `artifact_id`, `artifact_source`, `artifact_namespace`, `artifact_name` |
+
+Query to get all npm packages owned by OSO-tracked projects:
+
+```sql
+SELECT
+  p.project_name,
+  p.display_name,
+  a.artifact_namespace,
+  a.artifact_name AS npm_package
+FROM `<YOUR_GCP_PROJECT>.oso_production.projects_v1` AS p
+JOIN `<YOUR_GCP_PROJECT>.oso_production.artifacts_by_project_v1` AS a
+  ON p.project_id = a.project_id
+WHERE a.artifact_source = 'NPM'
+ORDER BY p.project_name
+```
+
+This yields a ready-made seed list of npm packages whose owning repos are already
+tracked by OSO — ideal for the first pass of the biibaa pipeline.
+
+---
+
+### 4. `key_metrics_by_project_v0` — Activity Metrics (confidence scoring)
+
+**Full identifier**: `` `<YOUR_GCP_PROJECT>.oso_production.key_metrics_by_project_v0` ``  
+**biibaa concern**: scoring — active contributors, recent commit count; supplement to
+`repositories_v0.updated_at`
+
+| Column | Type | Notes |
+|---|---|---|
+| `metric_id` | STRING | Join key to `metrics_v0` for human-readable name |
+| `project_id` | STRING | Join key to `projects_v1` |
+| `sample_date` | DATE | Date of measurement (most-recent snapshot) |
+| `amount` | FLOAT64 | Metric value |
+
+Relevant metric names (from `metrics_v0.metric_name`): `GITHUB_contributors_6_months`,
+`GITHUB_commits_6_months`, `GITHUB_issues_closed_6_months`.
+
+Query example:
+
+```sql
+SELECT
+  p.project_name,
+  m.metric_name,
+  km.sample_date,
+  km.amount
+FROM `<YOUR_GCP_PROJECT>.oso_production.key_metrics_by_project_v0` AS km
+JOIN `<YOUR_GCP_PROJECT>.oso_production.metrics_v0` AS m
+  ON km.metric_id = m.metric_id
+JOIN `<YOUR_GCP_PROJECT>.oso_production.projects_v1` AS p
+  ON km.project_id = p.project_id
+WHERE
+  m.metric_name IN ('GITHUB_contributors_6_months', 'GITHUB_commits_6_months')
+  AND p.project_name = 'lodash'
+ORDER BY km.sample_date DESC
+LIMIT 10
+```
+
+---
+
+## What OSO BigQuery Does Not Cover
+
+- **Arbitrary npm packages not in oss-directory**: `sboms_v0` only has data for the
+  ~7 000 curated OSS projects. For the long tail of npm packages (the "every dependent
+  of `debug`" case), OSO does not help — the direct `deps.dev` BigQuery public table
+  (`bigquery-public-data.deps_dev_v1.DependentsLatest`) is the right fallback (see
+  §Integration Plan below).
+- **Download counts**: OSO does not replicate npm download statistics. Keep the existing
+  `npm_downloads.py` adapter.
+- **OSV/CVE data**: Out of scope for OSO; biibaa owns this via OSV.dev.
+
+---
+
+## Integration Plan
+
+Priority order (highest value / lowest friction first):
+
+### Phase 1 — Replace ecosyste.ms with OSO for curated repos (immediate)
+
+Wire `sboms_v0` + `repositories_v0` into a new adapter
+`src/biibaa/adapters/oso_dependents.py`. For each flagged npm package:
+
+1. Query `sboms_v0` for dependent repos (filtered to `package_artifact_source = 'NPM'`).
+2. LEFT JOIN `repositories_v0` to get `star_count`, `updated_at`, `is_fork`.
+3. Apply biibaa disqualifiers (archived, no push in 24 months, forks) in the same SQL.
+4. Return a list of `(org, repo, repo_url, stars, days_since_push)` tuples.
+
+This single BigQuery query replaces one ecosyste.ms HTTP call + N GitHub REST calls.
+
+### Phase 2 — Seed from OSO project list (next sprint)
+
+Replace the current "seed with top-N npm packages" approach with a query against
+`projects_v1` + `artifacts_by_project_v1` to get a curated list of npm packages owned
+by OSO-tracked projects. This is a higher-quality seed than "top 1k by downloads"
+because it starts with projects the community has already decided are worth tracking.
+
+### Phase 3 — Long-tail fallback with deps.dev BigQuery (later)
+
+For packages not covered by `sboms_v0` (i.e. packages whose consumers are not in
+oss-directory), add a fallback that queries the public
+`bigquery-public-data.deps_dev_v1.DependentsLatest` table directly. This is a large
+public table (no subscription required, requester-pays on bytes scanned) that maps
+every npm package to its dependents by version range. It completes the coverage that
+OSO's curated subset leaves out.
+
+```sql
+-- deps.dev: top dependents of 'debug' on npm (no OSO subscription needed)
+SELECT
+  Name AS dependent_package,
+  Version AS dependent_version,
+  VersionInfo.Ordinal AS version_ordinal
+FROM `bigquery-public-data.deps_dev_v1.DependentsLatest`
+WHERE
+  System = 'NPM'
+  AND Dependency.Name = 'debug'
+ORDER BY VersionInfo.Ordinal DESC
+LIMIT 100
+```
+
+### Phase 4 — Activity metrics for confidence scoring (nice-to-have)
+
+Add `key_metrics_by_project_v0` to the biibaa scoring step to enrich the `impact`
+calculation with contributor and commit counts over the last 6 months. Higher recent
+activity → lower effort to land a PR → higher `effort` score.
+
+---
+
+## Implementation Notes
+
+- All queries should parameterize `<YOUR_GCP_PROJECT>` via an env var
+  `OSO_BQ_PROJECT` (set in `.env` / `biibaa` config).
+- Cache BigQuery results locally as Parquet under `data/raw/oso/<date>/` following
+  the existing idempotency convention.
+- Prefer the mart tables (`_v0`, `_v1`) over intermediate models (`int_*`) for
+  stability; OSO versions mart models and flags breaking changes.
+- `sboms_v0` is marked `kind FULL` and refreshed weekly — match biibaa's weekly cadence.

--- a/scripts/oso_bigquery_dependents.py
+++ b/scripts/oso_bigquery_dependents.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+oso_bigquery_dependents.py — Fetch top npm dependents via OSO BigQuery.
+
+This script is the proof-of-concept for replacing biibaa's ecosyste.ms
+fan-out adapter with OSO BigQuery. It maps directly onto the biibaa domain:
+
+  Input:  npm package name  (e.g. "lodash")
+  Output: list of GitHub repos that depend on that package,
+          enriched with star count, days-since-last-push, and repo URL —
+          ready to write into biibaa's `dependents` table.
+
+The SQL demonstrates what `src/biibaa/adapters/oso_dependents.py` would
+execute once integrated into the pipeline.
+
+Prerequisites
+-------------
+1. Subscribe to the OSO production dataset on BigQuery:
+   https://console.cloud.google.com/bigquery/analytics-hub/exchanges/projects/87806073973/locations/us/dataExchanges/open_source_observer_190181416ae/listings/oso_data_pipeline_190187c6517
+
+2. Install dependencies:
+   pip install google-cloud-bigquery pandas pyarrow
+
+3. Authenticate:
+   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+   # or: gcloud auth application-default login
+
+4. Set your GCP project ID:
+   export OSO_BQ_PROJECT=my-gcp-project
+
+Usage
+-----
+   python scripts/oso_bigquery_dependents.py lodash
+   python scripts/oso_bigquery_dependents.py chalk --limit 50
+   python scripts/oso_bigquery_dependents.py debug --dry-run
+"""
+
+import argparse
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+DEFAULT_LIMIT = 20
+DEFAULT_MIN_STARS = 0
+# Repos with no push in this many days are excluded (biibaa §6.4 disqualifier)
+DEFAULT_MAX_DAYS_SINCE_PUSH = 730  # 2 years
+
+
+# ---------------------------------------------------------------------------
+# SQL template
+# ---------------------------------------------------------------------------
+# The query joins two OSO mart tables:
+#
+#   oso_production.sboms_v0
+#     — reverse-dependency table: (dependent_repo → package) pairs
+#     — source: OSO ingests SBOM files from GitHub repos tracked in oss-directory
+#               and deps.dev PackageVersionToProject data
+#     — columns used: dependent_artifact_id, dependent_artifact_namespace,
+#                     dependent_artifact_name, package_artifact_source,
+#                     package_artifact_name
+#
+#   oso_production.repositories_v0
+#     — GitHub repo metadata: stars, last push, fork flag, language, licence
+#     — columns used: artifact_id (join key), star_count, updated_at, is_fork
+#
+# The result is ordered by star_count DESC so the highest-impact repos appear
+# first, matching biibaa's popularity-weighted scoring (§6.1).
+def build_sql(gcp_project: str, package_name: str, limit: int, max_days_since_push: int, min_stars: int) -> str:
+    return f"""
+-- oso_bigquery_dependents: top GitHub repos depending on npm package '{package_name}'
+--
+-- Tables:
+--   {gcp_project}.oso_production.sboms_v0
+--     SBOM-derived reverse-dependency map. Each row = (dependent_repo, package).
+--     Covers GitHub repos tracked by OSO's oss-directory that have published
+--     a machine-readable dependency manifest (package.json / GitHub dep graph).
+--
+--   {gcp_project}.oso_production.repositories_v0
+--     GitHub repo metadata. artifact_id joins to sboms_v0.dependent_artifact_id.
+--
+SELECT
+  s.dependent_artifact_namespace                                    AS org,
+  s.dependent_artifact_name                                        AS repo,
+  CONCAT(
+    'https://github.com/',
+    s.dependent_artifact_namespace, '/',
+    s.dependent_artifact_name
+  )                                                                 AS repo_url,
+  -- purl-style identifier, matching biibaa domain model §4.1
+  CONCAT(
+    'pkg:github/',
+    s.dependent_artifact_namespace, '/',
+    s.dependent_artifact_name
+  )                                                                 AS purl,
+  r.star_count,
+  r.language,
+  r.license_name,
+  DATE(r.updated_at)                                               AS last_push_date,
+  DATE_DIFF(CURRENT_DATE(), DATE(r.updated_at), DAY)               AS days_since_last_push,
+  r.is_fork
+FROM `{gcp_project}.oso_production.sboms_v0` AS s
+JOIN `{gcp_project}.oso_production.repositories_v0` AS r
+  ON s.dependent_artifact_id = r.artifact_id
+WHERE
+  -- filter to the npm ecosystem
+  s.package_artifact_source = 'NPM'
+  -- exact package name match (OSO stores names lowercase)
+  AND s.package_artifact_name = LOWER(@package_name)
+  -- biibaa §6.4: exclude forks (they rarely land PRs upstream)
+  AND r.is_fork = FALSE
+  -- biibaa §6.4: exclude repos inactive for > 2 years
+  AND r.updated_at > TIMESTAMP_SUB(
+    CURRENT_TIMESTAMP(), INTERVAL {max_days_since_push} DAY
+  )
+  -- optional star floor to reduce noise
+  AND r.star_count >= {min_stars}
+ORDER BY r.star_count DESC
+LIMIT {limit}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fetch top npm dependents via OSO BigQuery (biibaa fan-out replacement)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("package", help="npm package name, e.g. lodash")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help="maximum number of dependent repos to return",
+    )
+    parser.add_argument(
+        "--min-stars",
+        type=int,
+        default=DEFAULT_MIN_STARS,
+        dest="min_stars",
+        help="minimum star count for a dependent repo",
+    )
+    parser.add_argument(
+        "--max-days-since-push",
+        type=int,
+        default=DEFAULT_MAX_DAYS_SINCE_PUSH,
+        dest="max_days_since_push",
+        help="exclude repos with no commit in this many days",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the SQL without executing it",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    gcp_project = os.environ.get("OSO_BQ_PROJECT", "")
+    if not gcp_project and not args.dry_run:
+        print("ERROR: set OSO_BQ_PROJECT env var to your GCP project ID", file=sys.stderr)
+        sys.exit(1)
+
+    sql = build_sql(
+        gcp_project=gcp_project or "<YOUR_GCP_PROJECT>",
+        package_name=args.package,
+        limit=args.limit,
+        max_days_since_push=args.max_days_since_push,
+        min_stars=args.min_stars,
+    )
+
+    if args.dry_run:
+        print("=== DRY RUN — SQL that would be executed ===")
+        print(sql)
+        return
+
+    try:
+        from google.cloud import bigquery
+    except ImportError:
+        print(
+            "ERROR: google-cloud-bigquery not installed.\n"
+            "Run: pip install google-cloud-bigquery pandas pyarrow",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    client = bigquery.Client(project=gcp_project)
+
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("package_name", "STRING", args.package.lower()),
+        ]
+    )
+
+    print(f"Fetching dependents of npm:{args.package} from OSO BigQuery...")
+    print(f"  project={gcp_project}, limit={args.limit}, min_stars={args.min_stars}")
+    print()
+
+    query_job = client.query(sql, job_config=job_config)
+    rows = list(query_job.result())
+
+    if not rows:
+        print(
+            f"No dependents found for '{args.package}' in OSO's sboms_v0.\n"
+            "This means no repos in OSO's oss-directory have published a SBOM\n"
+            "that references this package, or the package name is misspelled."
+        )
+        return
+
+    # Print results in a format that mirrors biibaa's `dependents` table schema:
+    #   dependents(parent_purl, child_purl, rank)
+    print(f"{'rank':<5} {'purl':<50} {'stars':>6}  {'days_since_push':>15}  repo_url")
+    print("-" * 110)
+    for i, row in enumerate(rows, start=1):
+        print(
+            f"{i:<5} {row.purl:<50} {row.star_count:>6}  "
+            f"{row.days_since_last_push:>15}  {row.repo_url}"
+        )
+
+    print(f"\nTotal dependents returned: {len(rows)}")
+    print(
+        "\nNote: results cover only repos tracked by OSO's oss-directory + SBOM data.\n"
+        "For full npm dependent coverage, add a deps.dev fallback:\n"
+        "  SELECT Name, Version FROM bigquery-public-data.deps_dev_v1.DependentsLatest\n"
+        "  WHERE System='NPM' AND Dependency.Name=@package_name"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/oso_bigquery_probe.py
+++ b/scripts/oso_bigquery_probe.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+oso_bigquery_probe.py — Probe the OSO BigQuery dataset.
+
+Queries `oso_production.sboms_v0` joined to `repositories_v0` for a sample
+of high-star repos that depend on a curated set of npm packages. Demonstrates
+the fan-out replacement for ecosyste.ms.
+
+Prerequisites
+-------------
+1. Subscribe to the OSO production dataset on BigQuery:
+   https://console.cloud.google.com/bigquery/analytics-hub/exchanges/projects/87806073973/locations/us/dataExchanges/open_source_observer_190181416ae/listings/oso_data_pipeline_190187c6517
+   Create the linked dataset as `oso_production` in your GCP project.
+
+2. Install dependencies:
+   pip install google-cloud-bigquery pandas pyarrow
+
+3. Authenticate (choose one):
+   a) Service account:
+      export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+   b) Application Default Credentials (interactive):
+      gcloud auth application-default login
+
+4. Set your GCP project ID:
+   export OSO_BQ_PROJECT=my-gcp-project
+
+Usage
+-----
+   python scripts/oso_bigquery_probe.py
+"""
+
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+GCP_PROJECT = os.environ.get("OSO_BQ_PROJECT", "")
+if not GCP_PROJECT:
+    print("ERROR: set OSO_BQ_PROJECT env var to your GCP project ID", file=sys.stderr)
+    sys.exit(1)
+
+# Sample packages to probe — these are known to 500 on ecosyste.ms
+PROBE_PACKAGES = ["lodash", "chalk", "debug", "axios", "moment"]
+
+# ---------------------------------------------------------------------------
+# SQL
+# ---------------------------------------------------------------------------
+# This query:
+#   1. Looks up all GitHub repos in OSO's sboms_v0 that depend on the probed
+#      npm packages.
+#   2. Joins repositories_v0 to get star count, last-push date, fork flag.
+#   3. Filters to repos active in the last 2 years and not forks.
+#   4. Returns the top 5 results per package by star count.
+#
+# Table identifiers follow the pattern:
+#   `<YOUR_GCP_PROJECT>.oso_production.<table_name>`
+SQL = f"""
+WITH dependents AS (
+  SELECT
+    s.package_artifact_name                                         AS npm_package,
+    s.dependent_artifact_namespace                                  AS gh_org,
+    s.dependent_artifact_name                                       AS gh_repo,
+    CONCAT('https://github.com/',
+           s.dependent_artifact_namespace, '/',
+           s.dependent_artifact_name)                               AS repo_url,
+    r.star_count,
+    r.updated_at,
+    DATE_DIFF(CURRENT_DATE(), DATE(r.updated_at), DAY)              AS days_since_last_push,
+    r.is_fork,
+    ROW_NUMBER() OVER (
+      PARTITION BY s.package_artifact_name
+      ORDER BY r.star_count DESC
+    )                                                               AS rank_within_package
+  FROM `{GCP_PROJECT}.oso_production.sboms_v0` AS s
+  JOIN `{GCP_PROJECT}.oso_production.repositories_v0` AS r
+    ON s.dependent_artifact_id = r.artifact_id
+  WHERE
+    s.package_artifact_source = 'NPM'
+    AND s.package_artifact_name IN UNNEST(@packages)
+    AND r.is_fork = FALSE
+    AND r.updated_at > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 730 DAY)
+)
+SELECT
+  npm_package,
+  gh_org,
+  gh_repo,
+  repo_url,
+  star_count,
+  days_since_last_push
+FROM dependents
+WHERE rank_within_package <= 5
+ORDER BY npm_package, rank_within_package
+"""
+
+# ---------------------------------------------------------------------------
+# Execute
+# ---------------------------------------------------------------------------
+def main() -> None:
+    try:
+        from google.cloud import bigquery
+    except ImportError:
+        print(
+            "ERROR: google-cloud-bigquery not installed.\n"
+            "Run: pip install google-cloud-bigquery pandas pyarrow",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    client = bigquery.Client(project=GCP_PROJECT)
+
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ArrayQueryParameter("packages", "STRING", PROBE_PACKAGES),
+        ]
+    )
+
+    print(f"Running probe against project '{GCP_PROJECT}'...")
+    print(f"Packages: {PROBE_PACKAGES}\n")
+    print("SQL (abbreviated):")
+    print("  SELECT npm_package, gh_org, gh_repo, star_count, days_since_last_push")
+    print("  FROM oso_production.sboms_v0 JOIN oso_production.repositories_v0 ...")
+    print()
+
+    query_job = client.query(SQL, job_config=job_config)
+    rows = list(query_job.result())
+
+    if not rows:
+        print("No results returned. Check that sboms_v0 and repositories_v0 exist in")
+        print(f"your linked dataset '{GCP_PROJECT}.oso_production'.")
+        return
+
+    # Print results grouped by package
+    current_pkg = None
+    for row in rows:
+        if row.npm_package != current_pkg:
+            current_pkg = row.npm_package
+            print(f"--- npm: {current_pkg} ---")
+        print(
+            f"  {row.gh_org}/{row.gh_repo}"
+            f"  stars={row.star_count}"
+            f"  days_since_push={row.days_since_last_push}"
+            f"  {row.repo_url}"
+        )
+    print(f"\nTotal rows: {len(rows)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Rescues uncommitted scaffolding from a prior agent worktree before that worktree gets pruned.
- `docs/integrations/oso-bigquery.md` — scoping doc for replacing the ecosyste.ms fan-out (which 500s on hot packages like `lodash`, `debug`, `axios`) with OSO BigQuery's `sboms_v0 ⨝ repositories_v0`. Covers access model, relevant tables, integration phases, and known coverage gaps.
- `scripts/oso_bigquery_probe.py` — connectivity probe over a curated package list (`lodash`, `chalk`, `debug`, `axios`, `moment`).
- `scripts/oso_bigquery_dependents.py` — single-package POC matching the biibaa dependents-table shape; `--dry-run` prints the SQL for offline review.

No pipeline wiring is included — these stay opt-in via the `scripts/` entry points until we decide to fold OSO BigQuery into the pipeline alongside (or instead of) the existing pyoso adapter.

## Test plan
- [ ] `python scripts/oso_bigquery_dependents.py lodash --dry-run` prints the parameterized SQL without requiring GCP creds.
- [ ] With `OSO_BQ_PROJECT` set and ADC configured, `python scripts/oso_bigquery_probe.py` returns rows for at least one of the probed packages.
- [ ] `docs/integrations/oso-bigquery.md` renders correctly on GitHub (tables, code blocks, links).
