### PR TITLE
fix(fanout): drop dependents with no JS manifest at repo root

### DIFF
--- a/src/biibaa/adapters/github_repo.py
+++ b/src/biibaa/adapters/github_repo.py
@@ -41,6 +41,22 @@ GRAPHQL_URL = "https://api.github.com/graphql"
 # in a single HTTP fetch.
 MONOREPO_SENTINEL = "*MONOREPO*"
 
+# Sentinel returned when the repo has no JS manifest of any kind at root
+# (no package.json, no pnpm-lock.yaml / yarn.lock / package-lock.json).
+# OSO's sboms_v0 surfaces such repos when JS lives in a sub-tree, but a
+# transitive hit four levels deep under tooling isn't a contribution
+# opportunity for the root project — callers drop these candidates.
+NOT_JS_SENTINEL = "*NOT_JS*"
+
+# Lockfiles whose presence at root proves the repo treats JS as a top-level
+# concern. Used by fetch_direct_deps to distinguish "not a JS project at
+# root" (drop) from "transient fetch error" (fail open).
+_ROOT_LOCKFILES: tuple[str, ...] = (
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "package-lock.json",
+)
+
 # Workspace dependency sections in `pnpm-lock.yaml` `importers.<path>` whose
 # keys are direct deps of that workspace's `package.json`.
 _PNPM_DEP_SECTIONS: tuple[str, ...] = (
@@ -128,10 +144,17 @@ class GithubRepoSource:
         # Caches the parsed package.json so fetch_direct_deps and bench_info
         # share a single HTTP round-trip per repo. None = fetch/parse failed.
         self._pkg_cache: dict[tuple[str, str], dict | None] = {}
+        # Tracks whether package.json was definitively absent (404) vs failed
+        # for some other reason (parse error, network blip). Lets the
+        # transitive-filter distinguish "not a JS project" from "transient".
+        self._pkg_missing: dict[tuple[str, str], bool] = {}
         # Caches the union of direct-dep names across all workspaces parsed
         # from `pnpm-lock.yaml`. None = fetch or parse failed (caller falls
         # back to MONOREPO_SENTINEL).
         self._lockfile_cache: dict[tuple[str, str], set[str] | None] = {}
+        # Caches whether ANY root lockfile exists. None = couldn't tell
+        # (transient error). True/False are definitive.
+        self._has_root_lockfile_cache: dict[tuple[str, str], bool | None] = {}
 
     def _headers(self) -> dict[str, str]:
         h = {"Accept": "application/vnd.github+json"}
@@ -193,7 +216,9 @@ class GithubRepoSource:
         """Fetch + parse the repo's HEAD package.json, cached per repo.
 
         Returns the parsed JSON object, or None on any failure (parse error,
-        404, network error, non-object payload).
+        404, network error, non-object payload). Sets `self._pkg_missing`
+        when the failure is a definitive 404 so callers can distinguish
+        "no package.json at root" from "transient fetch error".
         """
         parsed = _parse_repo_url(repo_url)
         if not parsed:
@@ -204,6 +229,10 @@ class GithubRepoSource:
         url = f"https://raw.githubusercontent.com/{owner}/{name}/HEAD/package.json"
         try:
             r = self._client.get(url, headers=self._headers())
+            if r.status_code == 404:
+                self._pkg_cache[parsed] = None
+                self._pkg_missing[parsed] = True
+                return None
             r.raise_for_status()
             payload = json.loads(r.text)
         except (httpx.HTTPError, json.JSONDecodeError, ValueError) as e:
@@ -213,12 +242,42 @@ class GithubRepoSource:
                 error=str(e),
             )
             self._pkg_cache[parsed] = None
+            self._pkg_missing[parsed] = False
             return None
         if not isinstance(payload, dict):
             self._pkg_cache[parsed] = None
+            self._pkg_missing[parsed] = False
             return None
         self._pkg_cache[parsed] = payload
+        self._pkg_missing[parsed] = False
         return payload
+
+    def _has_any_root_lockfile(self, *, owner: str, name: str) -> bool | None:
+        """Return True/False if at least one root JS lockfile exists/none, or
+        None if we can't tell (transient error).
+
+        Uses HEAD requests so we don't pay the body cost — we only care about
+        existence. Caches the result per repo.
+        """
+        key = (owner, name)
+        if key in self._has_root_lockfile_cache:
+            return self._has_root_lockfile_cache[key]
+        any_unknown = False
+        for lf in _ROOT_LOCKFILES:
+            url = f"https://raw.githubusercontent.com/{owner}/{name}/HEAD/{lf}"
+            try:
+                r = self._client.head(url, headers=self._headers())
+            except httpx.HTTPError:
+                any_unknown = True
+                continue
+            if r.status_code == 200:
+                self._has_root_lockfile_cache[key] = True
+                return True
+            if r.status_code != 404:
+                any_unknown = True
+        result: bool | None = None if any_unknown else False
+        self._has_root_lockfile_cache[key] = result
+        return result
 
     def _fetch_pnpm_lockfile_deps(self, *, repo_url: str) -> set[str] | None:
         """Parse `pnpm-lock.yaml` and return the union of direct-dep names
@@ -272,18 +331,35 @@ class GithubRepoSource:
         """Return the set of names listed in `dependencies`+`devDependencies`
         of the repo's HEAD `package.json`.
 
-        Returns `None` on any failure (parse error, 404, network error) so
-        callers can treat the result as "unknown — don't filter". For monorepo
-        roots (a non-empty `workspaces` field), tries `pnpm-lock.yaml` first
-        — its `importers` map gives every workspace's direct deps in one
-        HTTP fetch, which lets the fan-out filter drop transitive-only hits
-        from lockfile-derived SBOMs (e.g. an iOS-tooling dep four levels deep
+        Returns `None` on transient failure (parse error, network error) so
+        callers can treat the result as "unknown — don't filter". When the
+        package.json is definitively absent (404) AND no JS lockfile exists
+        at root, returns `{NOT_JS_SENTINEL}` — the repo isn't a JS project
+        at root, so a SBOM-derived dependent hit there is almost certainly
+        transitive and should be dropped. For monorepo roots (a non-empty
+        `workspaces` field), tries `pnpm-lock.yaml` first — its `importers`
+        map gives every workspace's direct deps in one HTTP fetch, which
+        lets the fan-out filter drop transitive-only hits from
+        lockfile-derived SBOMs (e.g. an iOS-tooling dep four levels deep
         under Expo). Falls back to `{MONOREPO_SENTINEL}` when the lockfile
         is absent or unparseable so callers still treat the repo as
         "verified, don't filter".
         """
+        parsed = _parse_repo_url(repo_url)
+        if not parsed:
+            return None
         payload = self._fetch_pkg_json(repo_url=repo_url)
         if payload is None:
+            # Distinguish "no package.json at root" (404) from transient
+            # errors. Only the 404 case is worth probing further.
+            if not self._pkg_missing.get(parsed, False):
+                return None
+            owner, name = parsed
+            has_lockfile = self._has_any_root_lockfile(owner=owner, name=name)
+            if has_lockfile is False:
+                return {NOT_JS_SENTINEL}
+            # has_lockfile True (a lockfile exists despite no package.json)
+            # or None (couldn't tell) — fail open.
             return None
 
         # Monorepo detection: `workspaces` may be an array or an object with

--- a/src/biibaa/pipeline/run.py
+++ b/src/biibaa/pipeline/run.py
@@ -24,7 +24,11 @@ from biibaa.adapters._semver import is_version_in_range
 from biibaa.adapters.dependents_factory import build_dependents_source
 from biibaa.adapters.e18e import E18eReplacementsSource
 from biibaa.adapters.github_advisories import GithubAdvisorySource
-from biibaa.adapters.github_repo import MONOREPO_SENTINEL, GithubRepoSource
+from biibaa.adapters.github_repo import (
+    MONOREPO_SENTINEL,
+    NOT_JS_SENTINEL,
+    GithubRepoSource,
+)
 from biibaa.adapters.npm_downloads import NpmDownloadsSource
 from biibaa.adapters.npm_registry import NpmRegistrySource
 from biibaa.briefs.render import write_brief
@@ -272,7 +276,7 @@ def _fan_out_dependents(
         return candidates
 
     out: list[tuple[Replacement, Dependent]] = []
-    kept = dropped = unknown = monorepo = 0
+    kept = dropped = unknown = monorepo = not_js = 0
     for rep, dep in candidates:
         from_name = _project_name_from_purl(rep.from_purl)
         if not dep.repo_url:
@@ -286,6 +290,16 @@ def _fan_out_dependents(
             unknown += 1
             kept += 1
             out.append((rep, dep))
+            continue
+        if NOT_JS_SENTINEL in direct:
+            log.info(
+                "fanout.dropped_not_js_at_root",
+                from_pkg=from_name,
+                dependent=dep.name,
+                repo_url=dep.repo_url,
+            )
+            not_js += 1
+            dropped += 1
             continue
         if MONOREPO_SENTINEL in direct:
             monorepo += 1
@@ -309,6 +323,7 @@ def _fan_out_dependents(
         dropped=dropped,
         unknown=unknown,
         monorepo=monorepo,
+        not_js=not_js,
     )
     return out
 

--- a/tests/test_direct_deps_filter.py
+++ b/tests/test_direct_deps_filter.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 import httpx
 from pytest_httpx import HTTPXMock
 
-from biibaa.adapters.github_repo import MONOREPO_SENTINEL, GithubRepoSource
+from biibaa.adapters.github_repo import (
+    MONOREPO_SENTINEL,
+    NOT_JS_SENTINEL,
+    GithubRepoSource,
+)
 from biibaa.domain import Replacement
 from biibaa.pipeline.run import _fan_out_dependents
 from biibaa.ports.dependents import Dependent
@@ -179,15 +183,61 @@ def test_fetch_pnpm_lockfile_falls_back_when_no_importers(
     assert got == {MONOREPO_SENTINEL}
 
 
-def test_fetch_direct_deps_returns_none_on_404(httpx_mock: HTTPXMock) -> None:
+def test_fetch_direct_deps_returns_not_js_when_no_pkg_json_and_no_lockfiles(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Pure non-JS repo (e.g. Rust desktop app like zed-industries/zed):
+    package.json 404, every root lockfile 404 → mark as NOT_JS so callers
+    drop the candidate instead of leaking transitives from sub-trees."""
     httpx_mock.add_response(
-        url="https://raw.githubusercontent.com/ghost/missing/HEAD/package.json",
+        url="https://raw.githubusercontent.com/zed-industries/zed/HEAD/package.json",
         method="GET",
         status_code=404,
-        text="404: Not Found",
+    )
+    for lf in ("pnpm-lock.yaml", "yarn.lock", "package-lock.json"):
+        httpx_mock.add_response(
+            url=f"https://raw.githubusercontent.com/zed-industries/zed/HEAD/{lf}",
+            method="HEAD",
+            status_code=404,
+        )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    got = src.fetch_direct_deps(repo_url="https://github.com/zed-industries/zed")
+    assert got == {NOT_JS_SENTINEL}
+
+
+def test_fetch_direct_deps_returns_none_when_pkg_json_404_but_lockfile_present(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Some workflows commit a lockfile without the package.json at root
+    (rare, but seen in vendored bundles). Treat as transient/unknown — fail
+    open rather than dropping a possibly-real JS dependent."""
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/oddly/pkged/HEAD/package.json",
+        method="GET",
+        status_code=404,
+    )
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/oddly/pkged/HEAD/pnpm-lock.yaml",
+        method="HEAD",
+        status_code=200,
     )
     src = GithubRepoSource(token="x", client=httpx.Client())
-    assert src.fetch_direct_deps(repo_url="https://github.com/ghost/missing") is None
+    got = src.fetch_direct_deps(repo_url="https://github.com/oddly/pkged")
+    assert got is None
+
+
+def test_fetch_direct_deps_returns_none_on_transient_pkg_fetch_error(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """5xx / network blip on package.json is NOT a definitive 404 — never
+    probe lockfiles or mark as NOT_JS, just fail open."""
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/flaky/server/HEAD/package.json",
+        method="GET",
+        status_code=502,
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    assert src.fetch_direct_deps(repo_url="https://github.com/flaky/server") is None
 
 
 def test_fetch_direct_deps_returns_none_on_invalid_json(httpx_mock: HTTPXMock) -> None:
@@ -318,17 +368,17 @@ def test_filter_keeps_candidate_with_direct_dep(httpx_mock: HTTPXMock) -> None:
     assert [d.name for _, d in out] == ["consumer"]
 
 
-def test_filter_keeps_candidate_when_verification_returns_none(
+def test_filter_keeps_candidate_on_transient_verification_error(
     httpx_mock: HTTPXMock,
 ) -> None:
-    """404 / parse error → unknown, don't filter."""
+    """5xx / parse error on package.json → unknown, don't filter."""
     httpx_mock.add_response(
-        url="https://raw.githubusercontent.com/some/private/HEAD/package.json",
+        url="https://raw.githubusercontent.com/flaky/server/HEAD/package.json",
         method="GET",
-        status_code=404,
+        status_code=502,
     )
     eco = _StubEcoSrc(
-        [_dep("private-pkg", "https://github.com/some/private")]
+        [_dep("private-pkg", "https://github.com/flaky/server")]
     )
     downloads = _StubDownloadsSrc({"lodash.snakecase": 5_000_000})
     repo_src = _make_repo_src(httpx.Client())
@@ -341,6 +391,37 @@ def test_filter_keeps_candidate_when_verification_returns_none(
         repo_src=repo_src,
     )
     assert [d.name for _, d in out] == ["private-pkg"]
+
+
+def test_filter_drops_candidate_with_no_js_at_root(httpx_mock: HTTPXMock) -> None:
+    """The zed-industries/zed regression: a Rust repo with no package.json
+    and no JS lockfile at root surfaces in OSO sboms_v0 only via a sub-tree.
+    Every replacement candidate against such a repo is transitive — drop."""
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/zed-industries/zed/HEAD/package.json",
+        method="GET",
+        status_code=404,
+    )
+    for lf in ("pnpm-lock.yaml", "yarn.lock", "package-lock.json"):
+        httpx_mock.add_response(
+            url=f"https://raw.githubusercontent.com/zed-industries/zed/HEAD/{lf}",
+            method="HEAD",
+            status_code=404,
+        )
+    eco = _StubEcoSrc(
+        [_dep("zed", "https://github.com/zed-industries/zed")]
+    )
+    downloads = _StubDownloadsSrc({"lodash.once": 30_000_000})
+    repo_src = _make_repo_src(httpx.Client())
+    out = _fan_out_dependents(
+        replacements=[_replacement("lodash.once")],
+        eco_src=eco,  # type: ignore[arg-type]
+        downloads_src=downloads,  # type: ignore[arg-type]
+        fanout_top_n=10,
+        dependents_per_replacement=5,
+        repo_src=repo_src,
+    )
+    assert out == []
 
 
 def test_filter_keeps_candidate_for_monorepo_root_without_lockfile(


### PR DESCRIPTION
## Summary
Fixes briefs like [`data/briefs/npm/zed-industries__zed/2026-04-28.md`](data/briefs/npm/zed-industries__zed/2026-04-28.md) that recommend `lodash.once` / `colors` / `buffer-equal-constant-time` swaps to repos that don't actually have those packages as direct deps.

**Root cause.** Zed is a Rust project — no `package.json`, no `pnpm-lock.yaml`, no `yarn.lock`, no `package-lock.json` at root. OSO `sboms_v0` still surfaces it as a dependent because some sub-tree has JS manifests pulling those packages transitively. Our existing transitive-filter only acted on a *parsed* `package.json`; when the root file 404s the filter returned `None` and the caller treated it as "unknown — keep". Every transitive mention leaked through.

**Fix.**
1. `_fetch_pkg_json` now distinguishes a definitive 404 (file absent at HEAD) from a transient 5xx / parse error via a separate `_pkg_missing` flag.
2. New `_has_any_root_lockfile` issues HEAD requests for `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json` — cheap existence-only probes, cached per repo.
3. `fetch_direct_deps` returns a new `NOT_JS_SENTINEL` when **package.json is definitively absent AND no root lockfile exists**. The pipeline's `_fan_out_dependents` drops these candidates with a `fanout.dropped_not_js_at_root` log line.
4. Transient errors (5xx, network blip, parse failure) still fail open — we only drop when we have positive evidence of "no JS at root".

## Test plan
- [x] `uv run pytest` — 106 passed, 1 skipped.
- [x] `uv run ruff check` clean on touched files.
- [x] New tests cover: NOT_JS sentinel returned for the zed-industries/zed shape; lockfile-only repo (no package.json but has a lockfile) still fails open; 5xx on package.json still fails open; pipeline filter drops the candidate end-to-end.
- [ ] On next pipeline run: confirm `fanout.dropped_not_js_at_root` appears in logs and the next-day briefs no longer surface Rust/Go/etc. repos with synthetic-looking lodash.* opportunities.
