### PR TITLE
docs: align SPEC.md + README.md with MVP reality, add hero image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # biibaa
 
+![biibaa](site/biibaa.png)
+
 Open source improvement opportunity tracker. Pulls advisory + popularity data
 and emits ranked Markdown briefs of low-effort, high-impact contribution
 targets. See [SPEC.md](SPEC.md) for the full design.

--- a/README.md
+++ b/README.md
@@ -4,20 +4,29 @@ Open source improvement opportunity tracker. Pulls advisory + popularity data
 and emits ranked Markdown briefs of low-effort, high-impact contribution
 targets. See [SPEC.md](SPEC.md) for the full design.
 
+**Live site:** [biibaa.pages.dev](https://biibaa.pages.dev)
+
 ## MVP scope
 
 This first cut implements a vertical slice of the spec — enough to deliver the
 acceptance criteria of producing 20 actionable contribution briefs across all
-three opportunity axes (vulnerability, bloat, perf).
+three opportunity axes (vulnerability, bloat, perf), plus a static site that
+renders them.
 
 | Spec area | MVP | Follow-up |
 |---|---|---|
-| Sources | GHSA REST (unpatched-only) + npm bulk downloads + e18e module-replacements + ecosyste.ms dependents | OSV bulk, NVD, replacements.fyi, OSO BigQuery |
-| Storage | In-memory + Markdown out | Parquet raw landing → DuckDB warehouse |
-| Modeling | Python pipeline | SQLMesh staging → marts |
-| Scoring axes | Vulnerability + bloat + perf | Measured bytes-saved per replacement, benchmark deltas |
+| Vulnerability source | GHSA REST (unpatched-only by default) | OSV bulk, NVD CVSS |
+| Replacement source | e18e `module-replacements` (preferred / native / micro-utilities manifests) | replacements.fyi (bytes-saved, perf evidence) |
+| Popularity | npm bulk downloads + GitHub stars (log-norm) | Per-ecosystem references, dependents counts |
+| Dependents fan-out | Tiered: pyoso (`sboms_v0`, primary, GitHub repos) → ecosyste.ms (fallback, npm names) → SQLite weekly cache | Recursive fan-out, depth-2+ |
+| Project context | GitHub GraphQL (`isArchived`, last-merged-PR) + raw `package.json` / `pnpm-lock.yaml` for direct-dep verification | Reachability analysis, existing-PR dedupe |
+| Filtering | Outdated GHSA (`latest` no longer affected), transitive-only fan-out hits, `*NOT_JS*` repo roots, archived repos, weekly-downloads floor | "No commit in 24m", "replacement target itself flagged on OSV", maintainer WONTFIX learning |
+| Scoring axes | Vulnerability + bloat + perf — confidence axis (last-merged-PR decay) included | Measured bytes-saved per replacement, benchmark deltas |
 | Effort signal | Heuristic (version-bump = drop-in; e18e effort bands) | Codemod registry, breaking-change taxonomy |
-| Output | One brief per project, top-N with axis quota | Persisted opportunity history, state transitions |
+| Output | One brief per project, top-N with `top_n // 3` reserved for replacement-led briefs | Persisted opportunity history, state transitions |
+| Storage | In-memory pipeline + Markdown briefs (with YAML frontmatter) + SQLite dependents cache | Parquet raw landing → DuckDB warehouse, SQLMesh staging → marts |
+| Renderer | Astro 5 + Tailwind v4 static site (`site/`), Cloudflare Pages deploy | — |
+| Schedule | Local `biibaa run`; CI deploys the site on push | Daily-cron pipeline |
 
 ## Quickstart
 
@@ -26,7 +35,20 @@ uv sync
 uv run biibaa run --top 20
 ```
 
-Briefs land in `data/briefs/<ecosystem>/<project>/<yyyy-mm-dd>.md` (e.g. `data/briefs/npm/react__react/2026-04-27.md`).
+Briefs land in `data/briefs/<ecosystem>/<project>/<yyyy-mm-dd>.md` (e.g. `data/briefs/npm/reduxjs__react-redux/2026-04-27.md`). Each file is a Markdown body with structured YAML frontmatter (`schema: biibaa-brief/1`) consumable by the static site.
+
+### CLI flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--out` | `data/briefs` | Brief output dir |
+| `--top` | `20` | Number of briefs to render |
+| `--ecosystem` | `npm` | Only `npm` wired today |
+| `--advisory-limit` | `400` | Max GHSA advisories to ingest |
+| `--fanout-top-n` | `40` | Cap how many e18e mappings to fan out from |
+| `--dependents-per-replacement` | `5` | Top-K dependents pulled per replacement |
+| `--min-weekly-downloads` | `50000` | Drop projects below this floor |
+| `-v` / `--verbose` | off | Debug logs |
 
 ## Configuration
 
@@ -63,13 +85,31 @@ We deliberately exclude:
 
 ```
 src/biibaa/
-  domain/           # Pydantic v2 types: Project, Advisory, Opportunity, Brief
-  ports/            # Protocol classes for sources
-  adapters/         # github_advisories, npm_downloads (bulk), e18e
-  pipeline/         # Ingest → score → render orchestration
-  briefs/           # Jinja brief template + renderer
-  cli/              # Typer entry: `biibaa run`
-tests/              # pytest unit + adapter tests
+  domain/           # Pydantic v2 types: Project, Advisory, Replacement, Opportunity, Brief
+  ports/            # Protocol classes (DependentsSource)
+  adapters/         # github_advisories, github_repo, npm_downloads, npm_registry,
+                    # e18e, ecosyste_ms, pyoso_dependents, dependents_factory,
+                    # dependents_tiered, dependents_cache, _circuit, _http, _semver
+  pipeline/         # Ingest → fan-out → score → render orchestration
+  briefs/           # Jinja brief template + renderer (YAML frontmatter + Markdown body)
+  cli/              # Typer entry: `biibaa run`, `biibaa version`
+  scoring.py        # Popularity / severity / effort / confidence / final blend
+site/               # Astro 5 + Tailwind v4 static site (Cloudflare Pages)
+tests/              # pytest + pytest-httpx unit + adapter tests
+data/
+  briefs/<eco>/<slug>/<date>.md
+  dependents_cache.sqlite
+.github/workflows/deploy-site.yml
+```
+
+## Site
+
+`site/` is an Astro static site that renders the briefs for triage, deployed at [biibaa.pages.dev](https://biibaa.pages.dev). CI builds and deploys it on every push to `main` (paths: `site/**`, `data/briefs/**`). See [`site/README.md`](site/README.md) for first-time wiring of the `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` repo secrets.
+
+```sh
+cd site
+npm install
+npm run dev      # http://localhost:4321
 ```
 
 ## Behind a MITM proxy
@@ -84,3 +124,7 @@ loopback HTTPS_PROXY is detected (e.g. `ccli net start`). Set
 ```sh
 uv run pytest
 ```
+
+## Spec
+
+[SPEC.md](SPEC.md) is the design doc; sections are tagged ✅ built / ⚠️ partial / ❌ deferred so it tracks reality. SQLMesh + DuckDB warehouse (§8.2, §9.A) and the full subcommand surface (`ingest`, `brief`, `show`) are deferred — see the issues board for the follow-up backlog.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,6 +2,13 @@
 
 > Data engineering pipeline that surfaces low-effort, high-impact improvements to open source projects across **vulnerabilities**, **dependency weight**, and **performance**, then emits triage briefs.
 
+> **Status (2026-04-28)** — MVP is built end-to-end (`biibaa run` produces ranked briefs at
+> `data/briefs/<ecosystem>/<project>/<yyyy-mm-dd>.md`) and a static Astro site renders them.
+> Sources, storage, scoring, and pipeline sections below tag each item ✅ **built**, ⚠️ **partial**, or
+> ❌ **deferred**. SQLMesh / DuckDB warehouse (§8, §9) is deferred — current pipeline is in-memory
+> Python. See [README.md](README.md) for the operator-facing summary and the open issues for the
+> follow-up backlog.
+
 ## 1. Mission
 
 Continuously rank improvement opportunities in open source projects across three axes:
@@ -22,29 +29,36 @@ Output: deduplicated, ranked **briefs** (Markdown) — one per project — that 
 
 ## 3. Data sources
 
-| Source | Purpose | Refresh | Auth | Access |
-|---|---|---|---|---|
-| **OSV.dev** | vulnerability DB (multi-ecosystem) | daily bulk | none | bulk zip + REST |
-| **NVD CVE** | CVSS scores, references | daily incremental | optional API key | REST |
-| **GitHub** | repo metadata, security advisories, existing PRs/issues | on-demand | PAT/App | REST + GraphQL |
-| **e18e** | curated replacement candidates | weekly | none | GitHub repo pull |
-| **replacements.fyi** | per-package replacements with weight savings | weekly | none | site scrape / data export |
-| **npmjs.com/browse/depended/`<pkg>`** | top dependents per package — fan-out from a hot package to its consumers | weekly per seed | none | HTML scrape |
+| Source | Purpose | Refresh | Auth | Access | Status |
+|---|---|---|---|---|---|
+| **GitHub Security Advisories** (REST) | CVE/GHSA records, CVSS, fixed versions, source repo | per run | PAT (gh CLI fallback) | `api.github.com/advisories` | ✅ built (`adapters/github_advisories.py`) |
+| **GitHub repo (GraphQL + raw)** | `isArchived`, last-merged-PR, HEAD `package.json`, `pnpm-lock.yaml` | per run | PAT | GraphQL + `raw.githubusercontent.com` | ✅ built (`adapters/github_repo.py`) |
+| **e18e module-replacements** | curated replacement candidates (preferred / native / micro-utilities) | per run | none | `raw.githubusercontent.com/e18e/module-replacements` | ✅ built (`adapters/e18e.py`) |
+| **npm downloads API** | weekly download count (popularity signal) | per run | none | `api.npmjs.org/downloads/...` (bulk + per-package) | ✅ built (`adapters/npm_downloads.py`) |
+| **npm registry** | `latest` dist-tag for outdated-advisory filter | per run | none | `registry.npmjs.org` | ✅ built (`adapters/npm_registry.py`) |
+| **ecosyste.ms** | dependents fan-out (fallback) | per run | none | `packages.ecosyste.ms/api/v1/...` | ✅ built (`adapters/ecosyste_ms.py`) |
+| **Open Source Observer** (`pyoso`) | dependents fan-out (primary, GitHub-repo ranked by stars via `sboms_v0` ⋈ `repositories_v0`) | per run | `OSO_API_KEY` + `[pyoso]` extra | `pyoso.Client` | ✅ built (`adapters/pyoso_dependents.py`) |
+| **OSV.dev** bulk | multi-ecosystem vulnerability DB | daily bulk | none | bulk zip + REST | ❌ deferred |
+| **NVD CVE** | CVSS scores, references | daily incremental | optional API key | REST | ❌ deferred |
+| **replacements.fyi** | per-package replacements with weight savings | weekly | none | site scrape / data export | ❌ deferred |
+| **npmjs.com/browse/depended/`<pkg>`** | top dependents per package (fan-out via HTML scrape) | weekly per seed | none | HTML scrape | ❌ deferred — superseded by ecosyste.ms + pyoso |
 
 ### 3.1 Source notes
 
-- **OSV** is the primary advisory source; ecosystem and version-range coverage is broad. Bulk zips at `https://osv-vulnerabilities.storage.googleapis.com/<ecosystem>/all.zip`.
-- **NVD** complements OSV with CVSS metadata where OSV's severity is weak. Rate-limited; use API key.
-- **GitHub** is our project-context layer: stars, archived state, primary language, existing security advisories, and crucially **whether a PR is already open** for the same finding (dedupe).
-- **e18e** is a curated quality signal — small, opinionated, high-trust. Source likely `e18e/community` repo.
-- **replacements.fyi** offers structured `from → to` mappings with size/perf evidence; treat as canonical for replacement metadata.
-- **npm dependents browse** (`https://www.npmjs.com/browse/depended/<pkg>`) is **fan-out**: given a flagged package (vulnerable, heavy, or replaced), enumerate top dependents to widen the triage set. Also a popularity proxy. HTML-only; respect rate limits, cache aggressively.
+- **GHSA REST** is the MVP advisory source — filterable per-request (ecosystem + severity), structured JSON, and works without auth at low volume. The pipeline pulls only `first_patched_version is null` records by default: bumping a fixed version is dependabot's job; the contribution opportunity is to *write* the upstream patch.
+- **GitHub repo GraphQL** is the project-context layer: archived state and last-merged-PR drive the confidence axis. The same module also fetches HEAD `package.json` (and `pnpm-lock.yaml` for monorepos) to verify that fan-out hits actually have the flagged package as a *direct* dep — OSO's `sboms_v0` is lockfile-derived, so a transitive-only hit would otherwise pollute the triage set.
+- **e18e** is the curated replacement source. Manifests `preferred.json`, `native.json`, `micro-utilities.json` map from-package → replacement-id; `replacements` resolves each id to a target module (or `<native>` for built-in API). Replacements with no actionable target are skipped.
+- **npm downloads** powers the popularity log-norm in §6.1 and ranks which e18e mappings to fan out from (cap via `--fanout-top-n`).
+- **npm registry** drops GHSA records whose affected range no longer covers `latest` — GHSA frequently leaves `first_patched_version` null after a project moves past the affected range without backporting.
+- **Dependents fan-out** is tiered: pyoso (primary, GitHub repos with star ranks) → ecosyste.ms (fallback, npm package names with repo URLs) → SQLite cache (`data/dependents_cache.sqlite`) keyed by `(system, name, iso_week)`. Both backends are wrapped in a circuit breaker because hot packages (`lodash`, `debug`, `axios`, …) reliably 500 on ecosyste.ms.
+- **OSV / NVD / replacements.fyi / npm browse** — listed as deferred. OSV would replace GHSA REST as the primary advisory source for breadth; NVD adds CVSS where OSV is weak; replacements.fyi adds bytes-saved metadata to e18e mappings.
 
 ### 3.2 Source precedence on conflict
 
-- Vulnerability data: **OSV > GitHub Security Advisories > NVD**
-- Replacement data: **e18e > replacements.fyi**
-- Popularity: composite (see scoring §6), no single winner
+- Vulnerability data (current): **GHSA REST only**. Future: **OSV > GHSA > NVD**.
+- Replacement data: **e18e** (replacements.fyi deferred).
+- Dependents fan-out: **pyoso > ecosyste.ms** (selected at runtime by `adapters/dependents_factory.py` based on `OSO_API_KEY` + `[pyoso]` extra).
+- Popularity: composite (see scoring §6), no single winner.
 
 ## 4. Domain model
 
@@ -52,24 +66,27 @@ Output: deduplicated, ranked **briefs** (Markdown) — one per project — that 
 
 - `purl` — canonical id, [package URL](https://github.com/package-url/purl-spec) format (e.g. `pkg:npm/express`)
 - `ecosystem` — npm | pypi | go | rubygems | crates | maven | …
-- `name`, `repoUrl`, `homepage`
-- `popularity` — composite signal (stars + downloads + dependents)
-- `lastReleaseAt`, `lastCommitAt`
-- `archived: boolean`
+- `name`, `repo_url`, `homepage`
+- `stars`, `downloads_weekly`, `dependents` — raw popularity signals (composite computed in scoring §6)
+- `last_release_at`, `last_commit_at`, `last_pr_merged_at` — recency signals; `last_pr_merged_at` drives the confidence axis (§6.3)
+- `archived: bool`
+- `has_benchmarks: bool | None`, `bench_signal: str | None` — populated for replacement-driven projects from HEAD `package.json` (script names containing `bench`, `vitest|jest … bench` patterns, or known bench devDeps); `None` means we didn't check, surfaced in the brief frontmatter
 
 ### 4.2 Advisory (entity, references Project)
 
-- `id` — OSV id (`GHSA-…`, `CVE-…`)
-- `severity` — CVSS v3 score + qualitative band
-- `affectedVersions`, `fixedVersions` (version-range JSON)
-- `summary`, `references[]`
+- `id` — GHSA id (`GHSA-…`, `CVE-…`)
+- `severity` — CVSS v3 / v4 score (`cvss`) + qualitative band (`severity`)
+- `affected_versions` — string range (GHSA `vulnerable_version_range`)
+- `fixed_versions` — list of fixed versions; **empty when unpatched** (the pipeline filters to unpatched-only by default — see §3.1)
+- `summary`, `refs[]`, `published_at`
+- `repo_url` — source repo of the vulnerable package, used to point unpatched-vuln briefs at a concrete PR target
 
 ### 4.3 Replacement (entity, references Project)
 
-- `from: purl`
-- `to: purl[]` — sometimes multiple candidates
-- `axis: bloat | perf | maintenance | security`
-- `evidence` — bytes saved, benchmark link, e18e/replacements.fyi citation
+- `from_purl: purl`
+- `to_purls: purl[]` — sometimes multiple candidates; `pkg:npm/<native>` for native-API replacements
+- `axis: bloat | perf | maintenance | security` — only `bloat` and `perf` emitted today (e18e manifests don't surface the other two)
+- `evidence` — `{source, manifest, ids}` for e18e citations; bytes-saved metadata is deferred until replacements.fyi is wired up
 - `effort: drop-in | minor-migration | codemod-available | rewrite`
 
 ### 4.4 Opportunity (entity)
@@ -82,9 +99,9 @@ The unit of work surfaced to humans. One per `(project, axis, finding)`.
 - `impact: 0..100`
 - `effort: 0..100` (high = easy)
 - `score: number`
-- `dedupeKey` — for upserts across runs
-- `state: new | acknowledged | resolved | rejected | duplicate`
-- `firstSeenAt`, `lastSeenAt`
+- `dedupe_key` — for upserts across runs (`{project.purl}|{advisory.id}` or `{project.purl}|{replacement.id}`)
+- `state: new | acknowledged | resolved | rejected | duplicate` — type declared but **no cross-run persistence yet**; every run currently starts from `new`
+- `first_seen_at`, `last_seen_at`
 
 ### 4.5 Brief (aggregate)
 
@@ -93,9 +110,31 @@ The unit of work surfaced to humans. One per `(project, axis, finding)`.
 
 ### 4.6 Domain events
 
-`OpportunityDiscovered`, `OpportunityScored`, `BriefGenerated`
+`OpportunityDiscovered`, `OpportunityScored`, `BriefGenerated` — ❌ deferred. The current pipeline is a single in-process function; events would only be useful once we have cross-run state to drive (e.g. `state` transitions in §4.4).
 
 ## 5. Pipeline
+
+### 5.1 Today (MVP, in-memory Python — see `pipeline/run.py`)
+
+```
+GHSA REST ─┐
+e18e ──────┼──► aggregate by project ──► score ──► axis-quota top-N ──► render
+deps fan-out ─┘                                  (replacement quota = top_n // 3)
+```
+
+1. **Fetch advisories** — `GithubAdvisorySource.fetch()` (unpatched-only by default).
+2. **Drop outdated unpatched** — `_drop_outdated_unpatched` consults `NpmRegistrySource.latest_versions` and the affected range to discard advisories whose `latest` is no longer affected.
+3. **Fetch replacements** — `E18eReplacementsSource.fetch()` for npm.
+4. **Fan-out dependents** — `_fan_out_dependents` ranks e18e mappings by from-package weekly downloads, takes the top `--fanout-top-n`, and pulls `--dependents-per-replacement` dependents each via `build_dependents_source()` (pyoso primary → ecosyste.ms fallback → SQLite cache). Results are filtered against each dependent's HEAD `package.json` / `pnpm-lock.yaml` to drop transitive-only matches; `*NOT_JS*` (no JS manifest at root) hits are dropped, `*MONOREPO*` hits without a parseable lockfile are kept (fail open).
+5. **Hydrate projects** — bulk weekly downloads, GitHub repo meta (`is_archived`, `last_merged_pr_at`), and bench info (replacement-driven projects only, free cache hit).
+6. **Eligibility filter** — drop archived repos and packages below `--min-weekly-downloads` (default 50K).
+7. **Score** — vuln + replacement opportunities per project (§6); cap per-project at `max_opps_per_project=6`; head opportunity defines the project's score.
+8. **Axis-quota top-N** — `_select_with_axis_quota` reserves at least `top_n // 3` slots for replacement-led briefs so vuln-heavy ranking doesn't starve them; spillover refills the other axis.
+9. **Render** — Jinja2 Markdown body + YAML frontmatter (`schema: biibaa-brief/1`); written to `data/briefs/<ecosystem>/<slug>/<yyyy-mm-dd>.md`.
+
+The whole pipeline runs in-process. There is no `data/raw/` landing today.
+
+### 5.2 Aspirational (deferred — SQLMesh + DuckDB)
 
 ```
 sources → ingest (raw landing) → normalize (canonical model) → score → brief
@@ -103,11 +142,11 @@ sources → ingest (raw landing) → normalize (canonical model) → score → b
 
 1. **Ingest** — adapter per source pulls raw payloads. Stored as Parquet/JSON under `data/raw/<source>/<yyyy-mm-dd>/`. Idempotent per `(source, date)`.
 2. **Normalize** — SQLMesh staging models read raw Parquet via DuckDB's `read_parquet`, decode into typed staging tables; intermediate models apply source precedence (§3.2) and dedupe. Time-partitioned raw inputs map to `INCREMENTAL_BY_TIME_RANGE` models keyed on the ingest date.
-3. **Fan-out** — for each flagged package, enumerate top-K dependents via npm browse (and ecosyste.ms when extending) to expand the candidate set.
+3. **Fan-out** — for each flagged package, enumerate top-K dependents to expand the candidate set.
 4. **Score** — apply heuristics (§6). Materialize `opportunities` table.
-5. **Brief** — pick top-N projects by aggregate score; render Markdown briefs to `data/briefs/<ecosystem>/<project>/<yyyy-mm-dd>.md`.
+5. **Brief** — pick top-N projects by aggregate score; render Markdown briefs.
 
-Each step is idempotent and replayable from raw.
+Each step would be idempotent and replayable from raw. Status: ❌ deferred, see [Issues](#13-suggested-issues).
 
 ## 6. Scoring — "low-hanging fruit, high impact"
 
@@ -161,41 +200,103 @@ Predicts whether a drive-by PR will land. Driven by the upstream repo's most-rec
 
 ### 6.5 Disqualifiers
 
-- Project archived or no commit in 24 months → drop unless vuln severity ≥ 9
-- Replacement target itself flagged on OSV → drop
-- Existing open PR in repo proposing the same fix → de-prioritize, link instead
-- Project's own maintainers have explicitly declined the change (label / closed PR with WONTFIX) → drop, remember in `state: rejected`
+| Disqualifier | Status |
+|---|---|
+| Project archived | ✅ built (`pipeline.run._is_eligible`) |
+| Below weekly-downloads floor (`--min-weekly-downloads`, default 50K) | ✅ built (added beyond SPEC) |
+| Replacement target unmaintained / archived | ✅ built (effort table; archived disqualifier covers downstream) |
+| Outdated GHSA whose `latest` is no longer affected | ✅ built (`_drop_outdated_unpatched`) |
+| Fan-out hit with no JS manifest at repo root | ✅ built (`NOT_JS_SENTINEL`) |
+| Fan-out hit where flagged package is only transitive | ✅ built (`fetch_direct_deps` against `package.json` / `pnpm-lock.yaml`) |
+| No commit in 24 months → drop unless vuln severity ≥ 9 | ❌ deferred |
+| Replacement target itself flagged on OSV → drop | ❌ deferred |
+| Existing open PR proposing the same fix → de-prioritize, link instead | ❌ deferred |
+| Maintainers declined the change (WONTFIX) → drop, `state: rejected` | ❌ deferred (needs cross-run state) |
 
 ## 7. Brief format
 
-```md
-# <project> — <yyyy-mm-dd> Improvement Brief
+Briefs are emitted as `---\n<yaml frontmatter>\n---\n\n<markdown body>` (`schema: biibaa-brief/1`) so the static-site renderer (`site/`) can build cards/listings/filters from structured metadata without parsing the body. The body is plain Markdown for direct reading.
 
-**Ecosystem**: npm
-**Popularity**: ★ 12,400 · 2.1M downloads/wk · 8,201 dependents
-**Score**: 87 (impact 92, effort 75)
+### 7.1 Frontmatter (canonical)
+
+```yaml
+---
+schema: biibaa-brief/1
+title: react-redux
+slug: reduxjs__react-redux
+date: 2026-04-27
+run_at: 2026-04-27T10:14:33+00:00
+project:
+  purl: pkg:github/reduxjs/react-redux
+  name: reduxjs/react-redux
+  ecosystem: npm
+  repo_url: https://github.com/reduxjs/react-redux
+  downloads_weekly: 8420000
+  archived: false
+score:
+  total: 87.4
+  impact: 92.1
+  effort: 75.0
+  confidence: 100
+maintainer_activity:
+  label: last PR merged 3d ago
+  last_pr_merged_at: 2026-04-25T17:01:09+00:00
+benchmarks:
+  has: true
+  signal: script:bench
+opportunities:
+  count: 4
+  kinds: [dep-replacement, vulnerability-fix]
+  top_kind: vulnerability-fix
+tags: [bench, npm, unpatched, vuln]
+citations:
+  - {type: advisory, id: GHSA-xxxx-xxxx-xxxx, url: https://github.com/advisories/GHSA-xxxx-xxxx-xxxx}
+  - {type: e18e-replacement, id: micro-utilities.json, url: https://github.com/e18e/module-replacements/blob/main/manifests/micro-utilities.json}
+---
+```
+
+### 7.2 Body
+
+```md
+# react-redux — 2026-04-27 Improvement Brief
+
+**Repo**: [github.com/reduxjs/react-redux](https://github.com/reduxjs/react-redux)
 
 ## Top opportunities
 
-### 1. [vuln] CVE-2024-XXXX — RCE in transitive `tar` <6.2.1
-- **Severity**: 9.8 critical
-- **Fix**: bump `tar` to 6.2.1 (drop-in)
-- **Evidence**: OSV GHSA-…
-- **Suggested PR**: "fix(deps): bump tar to 6.2.1 (CVE-2024-XXXX)"
+### 1. [vulnerability-fix] GHSA-xxxx-xxxx-xxxx
+- **Severity**: high · CVSS 7.5
+- **Summary**: …
+- **Affected**: `<1.2.3`
+- **Fix**: _no upstream patch — contribute one_ at https://github.com/example/pkg
+- **Evidence**: [GHSA-xxxx-xxxx-xxxx](https://github.com/advisories/GHSA-xxxx-xxxx-xxxx)
+- **Effort score**: 20 / 100 (high = easy)
+- **Impact score**: 78 / 100
+- **Suggested PR**: `fix: address GHSA-xxxx-xxxx-xxxx in pkg`
 
-### 2. [bloat] Replace `moment` with `date-fns`
-- **Saves**: ~290 KB minified, no runtime change
-- **Evidence**: replacements.fyi · e18e curated
-- **Effort**: codemod available
-- **Suggested PR**: "perf(deps): replace moment with date-fns"
-
-## Citations
-- OSV: …
-- replacements.fyi: …
-- npm dependents (fan-out): https://www.npmjs.com/browse/depended/tar
+### 2. [dep-replacement] isarray → <native>
+- **Axis**: bloat
+- **Replace**: `isarray` → `<native>`
+- **Effort band**: drop-in
+- **Evidence**: e18e [module-replacements](https://github.com/e18e/module-replacements) · manifest `native.json`
+- **Effort score**: 95 / 100 (high = easy)
+- **Impact score**: 60 / 100
+- **Suggested PR**: `deps: drop isarray dep (use native API)`
 ```
 
-## 8. Storage (DuckDB, local-first)
+## 8. Storage
+
+### 8.1 Today (MVP)
+
+```
+data/
+  briefs/<ecosystem>/<project>/<yyyy-mm-dd>.md   # frontmatter + body
+  dependents_cache.sqlite                         # tiered fan-out cache, key (system, name, iso_week)
+```
+
+The MVP runs entirely in memory. There is no persistent warehouse; each `biibaa run` re-fetches sources (subject to the SQLite cache for dependents fan-out) and re-renders briefs.
+
+### 8.2 Aspirational (deferred — DuckDB + Parquet)
 
 ```
 data/
@@ -210,18 +311,24 @@ data/
   briefs/<project>/2026-04-26.md
 ```
 
-### 8.1 Core tables
+Core tables (planned):
 
 - `projects (purl PK, ecosystem, name, repo_url, stars, downloads_weekly, dependents, last_release_at, archived)`
 - `advisories (id PK, project_purl FK, severity, cvss, summary, fixed_versions JSON, refs JSON)`
 - `replacements (id PK, from_purl, to_purl, axis, effort, evidence JSON)`
-- `dependents (parent_purl, child_purl, rank)` — from npm browse fan-out
+- `dependents (parent_purl, child_purl, rank)` — fan-out edge list
 - `opportunities (id PK, project_purl, kind, payload_id, impact, effort, score, dedupe_key, state, first_seen_at, last_seen_at)`
 - `briefs (id PK, run_at, project_purl, path, score)`
 
 DuckDB chosen for: zero-ops, columnar joins across millions of `advisories × projects × dependents`, Parquet-native, fast local SQL exploration. Revisit when multi-user is real.
 
-## 9. Architecture (deferred — see scaffold step)
+## 9. Architecture
+
+### 9.0 Today (MVP)
+
+**Stack**: Python 3.12+ end-to-end. uv-managed venv. Hexagonal layout (ports + adapters). No SQLMesh / no DuckDB yet — see §9.A for the deferred slice and §13 for the issue list.
+
+### 9.1 Aspirational
 
 **Stack**: Python 3.12+ for ingest and orchestration; **SQLMesh** (with the DuckDB engine adapter) for transformation, modeling, audits, and incremental scheduling; DuckDB as the warehouse.
 
@@ -235,29 +342,17 @@ Rationale: data engineering work — API ingestion, Parquet/columnar transforms,
 
 This is a deliberate departure from the TypeScript/Effect-TS preference in `arch-taste.md`: that guidance targets application services. Any future UI/CLI surface for browsing briefs may still be TS.
 
-### 9.1 Layers
-
-| Layer | Tool | Responsibility |
-|---|---|---|
-| **Ingest** | Python (httpx, pydantic v2) | Pull from sources; land raw Parquet/JSON in `data/raw/<source>/<date>/` |
-| **Staging** | SQLMesh `INCREMENTAL_BY_TIME_RANGE` models (`read_parquet`) | Decode raw → typed staging tables; one staging model per source, partitioned by ingest date |
-| **Intermediate** | SQLMesh `VIEW` / `INCREMENTAL` models | Source-precedence resolution, joins, dedupe |
-| **Marts** | SQLMesh `FULL` or `INCREMENTAL` models | `projects`, `advisories`, `replacements`, `dependents`, `opportunities` |
-| **Score** | SQLMesh SQL + macros | Apply popularity + severity + effort heuristics; materialize `opportunities` |
-| **Audits** | SQLMesh audits | `not_null`, `unique_values`, `relationships`, custom (e.g. `score_in_range`) |
-| **Brief** | Python + Jinja2 | Read `opportunities` from DuckDB; render Markdown to `data/briefs/<ecosystem>/<project>/<date>.md` |
-| **CLI** | Python (Typer) | `biibaa ingest <source>`, `biibaa run`, `biibaa brief`, `biibaa show <project>` |
-
-### 9.2 Hexagonal split (Python)
+### 9.2 Hexagonal split (Python — built today)
 
 - `domain/` — Pydantic v2 models (`Project`, `Advisory`, `Replacement`, `Opportunity`, `Brief`); pure
-- `ports/` — `Protocol` classes (`SourceClient`, `WarehouseWriter`)
-- `adapters/` — per-source: `osv.py`, `nvd.py`, `github.py`, `e18e.py`, `replacements_fyi.py`, `npm_dependents.py`, `npm_downloads.py`, `github_stars.py`
-- `pipeline/` — ingest orchestration; thin (heavy lifting lives in SQLMesh)
-- `briefs/` — Jinja templates + render
-- `cli/` — Typer commands
+- `ports/` — `Protocol` classes (`DependentsSource`)
+- `adapters/` — `github_advisories.py`, `github_repo.py`, `e18e.py`, `npm_downloads.py`, `npm_registry.py`, `ecosyste_ms.py`, `pyoso_dependents.py`, `dependents_factory.py`, `dependents_tiered.py`, `dependents_cache.py`, `_circuit.py`, `_http.py`, `_semver.py`
+- `pipeline/run.py` — orchestrator (~500 lines)
+- `briefs/render.py` + `templates/brief.md.j2` — Jinja Markdown body + structured YAML frontmatter
+- `cli/main.py` — Typer entry: `biibaa run`, `biibaa version`
+- `scoring.py` — popularity / severity / effort / confidence / final blend
 
-### 9.3 Project layout
+### 9.3 Project layout (today)
 
 ```
 biibaa/
@@ -269,59 +364,86 @@ biibaa/
     pipeline/
     briefs/
     cli/
-  sqlmesh/
-    config.yaml                   # DuckDB gateway → data/warehouse.duckdb; state in same file
-    models/
-      staging/
-        stg_osv.sql               # INCREMENTAL_BY_TIME_RANGE on @start_ds / @end_ds
-        stg_nvd.sql
-        stg_github.sql
-        stg_e18e.sql
-        stg_replacements_fyi.sql
-        stg_npm_dependents.sql
-        stg_npm_downloads.sql
-      intermediate/
-        int_advisories_unified.sql
-        int_replacements_unified.sql
-        int_project_popularity.sql
-      marts/
-        projects.sql
-        advisories.sql
-        replacements.sql
-        dependents.sql
-        opportunities.sql
-    macros/
-      score_popularity.sql        # @DEF macros for log-norm popularity
-      score_severity.sql
-      score_effort.sql
-    audits/
-      score_in_range.sql          # custom audit: score ∈ [0, 100]
-      no_archived_active_opps.sql # custom audit: no opportunities on archived projects
-    tests/                        # SQLMesh model unit tests (synthetic input → expected output)
-  tests/                          # pytest unit + integration
+    scoring.py
+  site/                           # Astro + Tailwind v4 SSG (briefs renderer, Cloudflare Pages)
+  tests/                          # pytest + pytest-httpx unit + adapter tests
   data/                           # gitignored; created at runtime
-    raw/
-    warehouse.duckdb              # both warehouse data and SQLMesh state
-    briefs/
+    briefs/<ecosystem>/<project>/<yyyy-mm-dd>.md
+    dependents_cache.sqlite
+  .github/workflows/deploy-site.yml
 ```
 
-### 9.4 Tooling
+### 9.A Layers (deferred — SQLMesh + DuckDB)
+
+| Layer | Tool | Responsibility | Status |
+|---|---|---|---|
+| **Ingest** | Python (httpx, pydantic v2) | Pull from sources; land raw Parquet/JSON in `data/raw/<source>/<date>/` | ⚠️ partial — adapters built, but no Parquet landing |
+| **Staging** | SQLMesh `INCREMENTAL_BY_TIME_RANGE` models (`read_parquet`) | Decode raw → typed staging tables; one staging model per source, partitioned by ingest date | ❌ deferred |
+| **Intermediate** | SQLMesh `VIEW` / `INCREMENTAL` models | Source-precedence resolution, joins, dedupe | ❌ deferred |
+| **Marts** | SQLMesh `FULL` or `INCREMENTAL` models | `projects`, `advisories`, `replacements`, `dependents`, `opportunities` | ❌ deferred |
+| **Score** | SQLMesh SQL + macros | Apply popularity + severity + effort heuristics; materialize `opportunities` | ❌ deferred (lives in `scoring.py` today) |
+| **Audits** | SQLMesh audits | `not_null`, `unique_values`, `relationships`, custom (e.g. `score_in_range`) | ❌ deferred |
+| **Brief** | Python + Jinja2 | Read `opportunities` from DuckDB; render Markdown | ✅ built (reads in-memory, not DuckDB) |
+| **CLI** | Python (Typer) | `biibaa ingest <source>`, `biibaa run`, `biibaa brief`, `biibaa show <project>` | ⚠️ partial — `run` + `version` only; `ingest`/`brief`/`show` deferred |
+
+### 9.4 Tooling (today)
 
 - **uv** — package + lockfile + virtualenv management
-- **ruff** — lint + format
-- **mypy** — type-check `src/biibaa/`
-- **pytest** + **pytest-httpx** — adapter unit tests with fixture-recorded HTTP responses
-- **SQLMesh audits** + **SQLMesh tests** — schema + data assertions on every mart, plus model-level unit tests with declarative input/output fixtures
-- **Pydantic v2** — domain types and adapter response decoding (analogue to Effect Schema)
+- **ruff** — lint + format (CI not yet wired beyond `ruff check`)
+- **mypy** — declared in dev deps; not enforced in CI
+- **pytest** + **pytest-httpx** — adapter unit tests with fixture-recorded HTTP responses (✅ broad coverage)
+- **Pydantic v2** — domain types and adapter response decoding
+- **Astro 5 + Tailwind v4** (`site/`) — static site renderer for briefs
+- **SQLMesh audits / tests** — ❌ deferred along with the warehouse
 
 ## 10. Operations
 
-- **Schedule**: local CLI for now (`uv run biibaa ingest && sqlmesh run`); later GitHub Actions daily cron. `sqlmesh plan` gates merges to `main` so heuristic changes are reviewed against a row-level diff.
-- **Idempotency**: Python ingest writes date-partitioned dirs; SQLMesh interval state tracks which dates each model has processed, so re-runs are no-ops; opportunity dedupe via `dedupe_key` in marts
-- **Observability**: `structlog` for ingest; SQLMesh stores run history and intervals in its state DB (co-located in `warehouse.duckdb`), queryable for trend analysis
-- **Rate limiting**: per-source budget (NVD: 50 req/30s w/ key; npm browse: ≤1 req/s; GitHub: 5000/hr w/ PAT)
+### 10.1 Today
 
-## 11. Open questions
+- **Schedule**: local CLI only — `uv run biibaa run --top 20`. No cron yet for the pipeline.
+- **CI**: `.github/workflows/deploy-site.yml` builds `site/` and deploys to Cloudflare Pages on every push to `main` (paths: `site/**`, `data/briefs/**`).
+- **Idempotency**: same-day `biibaa run` re-fetches sources and overwrites the day's `data/briefs/<eco>/<slug>/<date>.md` deterministically. Dependents fan-out is cached weekly in `data/dependents_cache.sqlite`. No cross-run opportunity state.
+- **Observability**: `structlog` for ingest. Key events: `pipeline.start`, `pipeline.advisories_fetched`, `advisory.outdated_filter`, `fanout.dependents`, `fanout.direct_deps_filter`, `pipeline.eligibility_filter`, `pipeline.briefs_selected`, `pipeline.done`.
+- **Rate limiting**: per-source budgets — GitHub: 5000/hr w/ PAT (GHSA REST + GraphQL + raw `package.json`/lockfile fetches); npm bulk-downloads: 128 packages/request, 0.5s between batches, exponential backoff on 429; ecosyste.ms + pyoso both wrapped in `_circuit.CircuitBreaker` (3 failures → 5-minute open, fall through to fallback / `[]`).
+- **TLS / proxy**: `_http.make_client` honors `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`; auto-disables verification when `HTTPS_PROXY` points at a loopback (e.g. `ccli net start`); `BIIBAA_INSECURE_TLS=1` forces it off.
+
+### 10.2 Aspirational
+
+- **Schedule**: GitHub Actions daily cron on the pipeline. `sqlmesh plan` gates merges to `main` so heuristic changes are reviewed against a row-level diff.
+- **Idempotency**: SQLMesh interval state tracks which dates each model has processed, so re-runs are no-ops; opportunity dedupe via `dedupe_key` in marts.
+- **Observability**: SQLMesh run history co-located in `warehouse.duckdb`, queryable for trend analysis.
+
+## 11. CLI reference
+
+```sh
+uv run biibaa run [OPTIONS]
+uv run biibaa version
+```
+
+### `biibaa run`
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--out` | `data/briefs` | Brief output directory (per-ecosystem subdirs are created underneath). |
+| `--top` | `20` | Number of briefs to render. |
+| `--ecosystem` | `npm` | Ecosystem to ingest (only `npm` is wired today). |
+| `--advisory-limit` | `400` | Max advisories to ingest from GHSA. |
+| `--fanout-top-n` | `40` | Cap how many e18e mappings (ranked by from-package weekly downloads) to fan out from. |
+| `--dependents-per-replacement` | `5` | Top-K dependents pulled per fanned-out replacement. |
+| `--min-weekly-downloads` | `50000` | Drop projects below this floor. |
+| `-v` / `--verbose` | off | Debug-level structlog output. |
+
+Subcommands listed in earlier drafts (`biibaa ingest <source>`, `biibaa brief`, `biibaa show <project>`) are not implemented — `run` is the single end-to-end entry today.
+
+## 12. Static site (`site/`)
+
+Astro 5 + Tailwind v4 + a content collection whose schema mirrors `briefs/render.py:_build_frontmatter` (`schema: biibaa-brief/1`). Reads briefs straight from `../data/briefs/`, builds a static bundle in `site/dist/`, deploys to Cloudflare Pages via `.github/workflows/deploy-site.yml` on every push to `main` that touches `site/**` or `data/briefs/**`. See `site/README.md` for first-time wiring of the `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets.
+
+## 13. Suggested issues
+
+The MVP intentionally cuts most of §8 (warehouse) and §9.A (SQLMesh) to ship a working brief renderer. The follow-up backlog is tracked as separate issues — see the [drift summary](.tmp/drift-2026-04-28.md) and the issues board for the canonical list.
+
+## 14. Open questions
 
 1. **Project universe** — long tail of every package, or seed with watchlist (top 1k npm by dependents) and expand via fan-out?
 2. **Reachability** — attempt static reachability analysis ("is the vulnerable code path actually called?") or treat any direct dep as reachable enough? High value, expensive.
@@ -329,7 +451,3 @@ biibaa/
 4. **Brief audience** — for upstream maintainers (terse, PR-oriented) or for an internal triage queue (detailed, rationale-heavy)? Affects template.
 5. **Multi-language scope** — npm-only first, or polyglot from day one? OSV is language-agnostic but popularity signals differ per ecosystem.
 6. **Fan-out depth** — for npm dependents, take only direct dependents (depth=1) or recurse to depth=2+? Recursion explodes the candidate set fast.
-
----
-
-**Next step after sign-off**: scaffold the Python project (`uv init`) + SQLMesh project (`sqlmesh init duckdb`), then TDD `domain` + `adapters/osv.py` to deliver the end-to-end happy path: OSV → raw Parquet → SQLMesh staging → `opportunities` mart → Markdown brief.


### PR DESCRIPTION
## Summary

- Tag every SPEC.md section with ✅ built / ⚠️ partial / ❌ deferred so the doc tracks reality. The walking-skeleton landed without an accompanying spec update, so OSV/NVD ingest, replacements.fyi, Parquet raw landing, SQLMesh + DuckDB warehouse, and `biibaa ingest|brief|show` subcommands were all listed as "current" while only being aspirational.
- Update README.md MVP table, add CLI flags reference, full layout, Site section, and the live-site link ([biibaa.pages.dev](https://biibaa.pages.dev)) at the top.
- Add `site/biibaa.png` hero image and embed it at the top of README.md.
- The full follow-up backlog is consolidated into tracking issue #23.

## Notable SPEC.md changes

- §3 sources: now lists what's wired (GHSA REST, e18e, npm downloads/registry, ecosyste.ms, pyoso, GitHub repo) and tags OSV / NVD / replacements.fyi / npm browse-depended as deferred.
- §4 domain types match the pydantic models in code (incl. `last_pr_merged_at`, `has_benchmarks`, `bench_signal`, `Advisory.repo_url`).
- §5 split into §5.1 (today, in-memory Python) and §5.2 (deferred SQLMesh/DuckDB). Documents the GHSA filter, fan-out direct-deps verification, axis-quota top-N.
- §6.5 disqualifier table tracks built vs deferred.
- §7 frontmatter spec for `schema: biibaa-brief/1` (matches `briefs/render.py`).
- §8 / §9 / §10 each split today vs aspirational.
- New §11 CLI reference (just `run` + `version`), §12 site, §13 pointer to the tracking issue.

## Test plan

- [ ] Render PR diff side-by-side and skim — no factual claim about source / scoring / storage / CLI is contradicted by the code.
- [ ] [biibaa.pages.dev](https://biibaa.pages.dev) link in README header resolves.
- [ ] Hero image renders on the GitHub-rendered README.
- [ ] No code changes — CI should be a no-op other than docs lint.
