### PR TITLE
feat(site): open brief in side drawer + GitHub/npm links

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -28,7 +28,6 @@ const { title = "biibaa", description = "Open source improvement opportunity tra
     <main class="max-w-[1600px] mx-auto px-5 py-4">
       <header class="flex items-baseline gap-3 mb-4">
         <a href="/" class="text-3xl font-semibold tracking-tight text-white no-underline">biibaa</a>
-        <span class="text-sm text-[var(--color-muted)]">triage</span>
         <span class="ml-auto text-xs text-[var(--color-muted)]">
           <slot name="header-right" />
         </span>

--- a/site/src/pages/briefs/[...id].astro
+++ b/site/src/pages/briefs/[...id].astro
@@ -15,6 +15,10 @@ const { Content } = await render(brief);
 const fm = brief.data;
 const score = fm.score;
 const repo = fm.project.repo_url;
+const npmUrl =
+  fm.project.ecosystem === "npm" && fm.project.name
+    ? `https://www.npmjs.com/package/${fm.project.name}`
+    : null;
 ---
 
 <Base title={`${fm.title} — biibaa`} description={`Improvement brief for ${fm.title}`}>
@@ -54,8 +58,22 @@ const repo = fm.project.repo_url;
           <div><span class="text-[var(--color-muted)]">Eco</span> · <span class="mono">{fm.project.ecosystem}</span></div>
           {repo && (
             <div>
-              <a href={repo} target="_blank" rel="noopener" class="text-[var(--color-accent)] mono text-xs">
-                {repo.replace(/^https?:\/\//, "")}
+              <a href={repo} target="_blank" rel="noopener" class="inline-flex items-center gap-1.5 text-[var(--color-accent)] mono text-xs">
+                <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                </svg>
+                {repo.replace(/^https?:\/\//, "").replace(/^github\.com\//, "")}
+              </a>
+            </div>
+          )}
+          {npmUrl && (
+            <div>
+              <a href={npmUrl} target="_blank" rel="noopener" class="inline-flex items-center gap-1.5 text-[var(--color-accent)] mono text-xs">
+                <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+                  <rect width="16" height="16" rx="1" fill="#cb3837"/>
+                  <path d="M3 4h10v8H8.5V6H7v6H3V4z" fill="#fff"/>
+                </svg>
+                npmjs.com/package/{fm.project.name}
               </a>
             </div>
           )}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -61,7 +61,7 @@ const columns = [
 const labels = Object.fromEntries(columns.map((c) => [c.name, c.label]));
 ---
 
-<Base title="biibaa — triage">
+<Base title="biibaa">
   <span slot="header-right">{rows.length} briefs · {all.length} total dated</span>
 
   <div
@@ -154,7 +154,7 @@ const labels = Object.fromEntries(columns.map((c) => [c.name, c.label]));
         </thead>
         <tbody>
           <template x-for="row in visibleRows" :key="row.slug">
-            <tr @click="window.location = row.href">
+            <tr @click="onRowClick(row, $event)">
               {columns.map((c) => {
                 if (c.isTags) {
                   return (
@@ -183,6 +183,36 @@ const labels = Object.fromEntries(columns.map((c) => [c.name, c.label]));
         </tbody>
       </table>
     </div>
+
+    <!-- Drawer -->
+    <div
+      x-show="drawer.open"
+      x-transition.opacity
+      class="drawer-backdrop"
+      @click="closeDrawer()"
+      style="display: none;"
+    ></div>
+    <aside
+      class="drawer-panel"
+      :class="drawer.open ? 'open' : ''"
+      role="dialog"
+      aria-modal="true"
+      @keydown.escape.window="closeDrawer()"
+    >
+      <div class="drawer-head">
+        <a
+          :href="drawer.href"
+          class="text-[var(--color-muted)] hover:text-[var(--color-text)] text-xs"
+          title="Open standalone page"
+        >open in page →</a>
+        <button @click="closeDrawer()" class="drawer-close" aria-label="Close">×</button>
+      </div>
+      <div class="drawer-body">
+        <div x-show="drawer.loading" class="text-[var(--color-muted)] text-sm p-6">Loading…</div>
+        <div x-show="drawer.error" class="text-amber-400 text-sm p-6" x-text="drawer.error"></div>
+        <div x-show="!drawer.loading && !drawer.error" x-html="drawer.html"></div>
+      </div>
+    </aside>
   </div>
 
   <script is:inline src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
@@ -204,6 +234,16 @@ const labels = Object.fromEntries(columns.map((c) => [c.name, c.label]));
           hideArchived: true,
           search: "",
         },
+        drawer: {
+          open: false,
+          loading: false,
+          error: "",
+          href: "",
+          html: "",
+          cache: {},
+          prevTitle: "",
+          prevPath: "",
+        },
 
         init() {
           // Wire column-header click → push/flip on the sort stack.
@@ -213,6 +253,85 @@ const labels = Object.fromEntries(columns.map((c) => [c.name, c.label]));
               th.addEventListener("click", () => this.toggleSort(th.dataset.col));
             });
           });
+          // Browser back closes drawer instead of leaving the page.
+          window.addEventListener("popstate", () => {
+            if (this.drawer.open) this._teardownDrawer();
+          });
+        },
+
+        onRowClick(row, ev) {
+          // Let modifier / middle clicks fall through to a real navigation
+          // so users keep "open in new tab" behavior.
+          if (ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.button === 1) {
+            window.open(row.href, "_blank");
+            return;
+          }
+          this.openDrawer(row.href);
+        },
+
+        async openDrawer(href) {
+          this.drawer.prevTitle = document.title;
+          this.drawer.prevPath = location.pathname + location.search + location.hash;
+          this.drawer.href = href;
+          this.drawer.open = true;
+          this.drawer.error = "";
+          document.body.classList.add("drawer-locked");
+          history.pushState({ drawer: true, href }, "", href);
+
+          if (this.drawer.cache[href]) {
+            this.drawer.html = this.drawer.cache[href].html;
+            this.drawer.loading = false;
+            if (this.drawer.cache[href].title) document.title = this.drawer.cache[href].title;
+            return;
+          }
+
+          this.drawer.html = "";
+          this.drawer.loading = true;
+          try {
+            const res = await fetch(href, { headers: { Accept: "text/html" } });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const text = await res.text();
+            const doc = new DOMParser().parseFromString(text, "text/html");
+            const main = doc.querySelector("main");
+            if (!main) throw new Error("Could not find content");
+            // Drop the page header — the drawer has its own chrome.
+            const fragment = document.createElement("div");
+            main.querySelectorAll(":scope > header").forEach((h) => h.remove());
+            fragment.append(...main.childNodes);
+            const title = doc.querySelector("title")?.textContent ?? "";
+            const html = fragment.innerHTML;
+            this.drawer.cache[href] = { html, title };
+            // Only apply if user hasn't navigated away in the meantime.
+            if (this.drawer.href === href && this.drawer.open) {
+              this.drawer.html = html;
+              if (title) document.title = title;
+            }
+          } catch (e) {
+            this.drawer.error = `Failed to load: ${e.message}. Falling back to page navigation.`;
+            window.location = href;
+          } finally {
+            this.drawer.loading = false;
+          }
+        },
+
+        closeDrawer() {
+          if (!this.drawer.open) return;
+          // If we pushed state to open it, going back unwinds cleanly and
+          // the popstate handler tears down. Otherwise tear down directly.
+          if (history.state && history.state.drawer) {
+            history.back();
+          } else {
+            this._teardownDrawer();
+          }
+        },
+
+        _teardownDrawer() {
+          this.drawer.open = false;
+          this.drawer.loading = false;
+          this.drawer.error = "";
+          this.drawer.html = "";
+          document.body.classList.remove("drawer-locked");
+          if (this.drawer.prevTitle) document.title = this.drawer.prevTitle;
         },
 
         get visibleRows() {

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -242,3 +242,62 @@ body {
   outline: none;
   border-color: var(--color-accent);
 }
+
+/* Brief drawer */
+.drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgb(0 0 0 / 0.55);
+  backdrop-filter: blur(2px);
+  z-index: 40;
+}
+.drawer-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(960px, 92vw);
+  background: var(--color-bg);
+  border-left: 1px solid var(--color-border-strong);
+  box-shadow: -24px 0 48px -16px rgb(0 0 0 / 0.6);
+  z-index: 50;
+  transform: translateX(100%);
+  transition: transform 220ms cubic-bezier(0.32, 0.72, 0, 1);
+  display: flex;
+  flex-direction: column;
+}
+.drawer-panel.open {
+  transform: translateX(0);
+}
+.drawer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+.drawer-close {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-muted);
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+.drawer-close:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-strong);
+}
+.drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+}
+body.drawer-locked {
+  overflow: hidden;
+}


### PR DESCRIPTION
## Summary

- Project rows on the triage table open the brief in a right-side drawer instead of navigating away. The drawer fetches the existing static brief page, strips the duplicate header, and injects the content. `pushState` keeps the URL shareable; back / Esc / backdrop / × all close. Cmd/Ctrl/Shift/middle-click still falls through to a real navigation so "open in new tab" keeps working.
- Brief sidebar gets a GitHub icon next to the repo link, plus an npm icon + `npmjs.com/package/<name>` link when `ecosystem === "npm"`.
- Drop the "triage" subtitle from the header and the index page title.

## How it works

- `site/src/pages/index.astro` — Alpine state gains `drawer.{open, loading, error, href, html, cache}` plus `onRowClick / openDrawer / closeDrawer / _teardownDrawer`. Fetched HTML is cached per-href; `popstate` tears down the drawer when the user hits back.
- `site/src/styles/global.css` — `.drawer-backdrop`, `.drawer-panel`, `.drawer-head`, `.drawer-close`, `.drawer-body`, `body.drawer-locked`.
- `site/src/pages/briefs/[...id].astro` — adds inline GitHub SVG + computed `npmUrl` link.
- `site/src/layouts/Base.astro` — removes the "triage" span.

## Test plan

- [x] `npm run build` (477 pages built clean)
- [x] `npm run dev` boots and the index renders with `.drawer-*` styles + `onRowClick`
- [ ] Browser smoke: click row → drawer slides in, content loads, URL updates
- [ ] Esc / × / backdrop click all close the drawer
- [ ] Browser back closes the drawer (and forward re-opens — stretch)
- [ ] Cmd/Ctrl/middle-click row opens the brief in a new tab
- [ ] npm-ecosystem brief shows both GitHub + npm links; non-npm brief shows only GitHub
