### PR TITLE
feat(briefs): flat output + exact citations (manifest deep links + dep-location permalinks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ uv sync
 uv run biibaa run --top 20
 ```
 
-Briefs land in `data/briefs/<ecosystem>/<project>/<yyyy-mm-dd>.md` (e.g. `data/briefs/npm/reduxjs__react-redux/2026-04-27.md`). Each file is a Markdown body with structured YAML frontmatter (`schema: biibaa-brief/1`) consumable by the static site.
+Briefs land in `data/briefs/<ecosystem>/<slug>.md` (e.g. `data/briefs/npm/reduxjs__react-redux.md`). Each run overwrites the previous brief for a project; ineligible projects drop out of the directory automatically. Each file is a Markdown body with structured YAML frontmatter (`schema: biibaa-brief/1`) consumable by the static site.
 
 ### CLI flags
 
@@ -99,7 +99,7 @@ src/biibaa/
 site/               # Astro 5 + Tailwind v4 static site (Cloudflare Pages)
 tests/              # pytest + pytest-httpx unit + adapter tests
 data/
-  briefs/<eco>/<slug>/<date>.md
+  briefs/<eco>/<slug>.md
   dependents_cache.sqlite
 .github/workflows/deploy-site.yml
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -3,7 +3,7 @@
 > Data engineering pipeline that surfaces low-effort, high-impact improvements to open source projects across **vulnerabilities**, **dependency weight**, and **performance**, then emits triage briefs.
 
 > **Status (2026-04-28)** — MVP is built end-to-end (`biibaa run` produces ranked briefs at
-> `data/briefs/<ecosystem>/<project>/<yyyy-mm-dd>.md`) and a static Astro site renders them.
+> `data/briefs/<ecosystem>/<slug>.md`, overwriting prior runs in place) and a static Astro site renders them.
 > Sources, storage, scoring, and pipeline sections below tag each item ✅ **built**, ⚠️ **partial**, or
 > ❌ **deferred**. SQLMesh / DuckDB warehouse (§8, §9) is deferred — current pipeline is in-memory
 > Python. See [README.md](README.md) for the operator-facing summary and the open issues for the
@@ -130,7 +130,7 @@ deps fan-out ─┘                                  (replacement quota = top_n 
 6. **Eligibility filter** — drop archived repos and packages below `--min-weekly-downloads` (default 50K).
 7. **Score** — vuln + replacement opportunities per project (§6); cap per-project at `max_opps_per_project=6`; head opportunity defines the project's score.
 8. **Axis-quota top-N** — `_select_with_axis_quota` reserves at least `top_n // 3` slots for replacement-led briefs so vuln-heavy ranking doesn't starve them; spillover refills the other axis.
-9. **Render** — Jinja2 Markdown body + YAML frontmatter (`schema: biibaa-brief/1`); written to `data/briefs/<ecosystem>/<slug>/<yyyy-mm-dd>.md`.
+9. **Render** — Jinja2 Markdown body + YAML frontmatter (`schema: biibaa-brief/1`); written to `data/briefs/<ecosystem>/<slug>.md`. Each run overwrites the previous brief for a project, so projects that drop out of eligibility disappear from the directory on the next run.
 
 The whole pipeline runs in-process. There is no `data/raw/` landing today.
 
@@ -290,7 +290,7 @@ citations:
 
 ```
 data/
-  briefs/<ecosystem>/<project>/<yyyy-mm-dd>.md   # frontmatter + body
+  briefs/<ecosystem>/<slug>.md                    # frontmatter + body, overwritten per run
   dependents_cache.sqlite                         # tiered fan-out cache, key (system, name, iso_week)
 ```
 
@@ -368,7 +368,7 @@ biibaa/
   site/                           # Astro + Tailwind v4 SSG (briefs renderer, Cloudflare Pages)
   tests/                          # pytest + pytest-httpx unit + adapter tests
   data/                           # gitignored; created at runtime
-    briefs/<ecosystem>/<project>/<yyyy-mm-dd>.md
+    briefs/<ecosystem>/<slug>.md
     dependents_cache.sqlite
   .github/workflows/deploy-site.yml
 ```
@@ -402,7 +402,7 @@ biibaa/
 
 - **Schedule**: local CLI only — `uv run biibaa run --top 20`. No cron yet for the pipeline.
 - **CI**: `.github/workflows/deploy-site.yml` builds `site/` and deploys to Cloudflare Pages on every push to `main` (paths: `site/**`, `data/briefs/**`).
-- **Idempotency**: same-day `biibaa run` re-fetches sources and overwrites the day's `data/briefs/<eco>/<slug>/<date>.md` deterministically. Dependents fan-out is cached weekly in `data/dependents_cache.sqlite`. No cross-run opportunity state.
+- **Idempotency**: every `biibaa run` re-fetches sources and overwrites `data/briefs/<eco>/<slug>.md` deterministically. Projects that fall out of eligibility on a later run drop off disk on the next run (the renderer never appends, only overwrites the eligible set). Dependents fan-out is cached weekly in `data/dependents_cache.sqlite`. No cross-run opportunity state.
 - **Observability**: `structlog` for ingest. Key events: `pipeline.start`, `pipeline.advisories_fetched`, `advisory.outdated_filter`, `fanout.dependents`, `fanout.direct_deps_filter`, `pipeline.eligibility_filter`, `pipeline.briefs_selected`, `pipeline.done`.
 - **Rate limiting**: per-source budgets — GitHub: 5000/hr w/ PAT (GHSA REST + GraphQL + raw `package.json`/lockfile fetches); npm bulk-downloads: 128 packages/request, 0.5s between batches, exponential backoff on 429; ecosyste.ms + pyoso both wrapped in `_circuit.CircuitBreaker` (3 failures → 5-minute open, fall through to fallback / `[]`).
 - **TLS / proxy**: `_http.make_client` honors `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`; auto-disables verification when `HTTPS_PROXY` points at a loopback (e.g. `ccli net start`); `BIIBAA_INSECURE_TLS=1` forces it off.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -4,16 +4,9 @@ import Base from "../layouts/Base.astro";
 
 const all = await getCollection("briefs");
 
-// Latest brief per slug — multiple dates exist for the same project; the
-// triage table only shows the freshest.
-const latestBySlug = new Map<string, (typeof all)[number]>();
-for (const b of all) {
-  const existing = latestBySlug.get(b.data.slug);
-  if (!existing || b.data.date > existing.data.date) {
-    latestBySlug.set(b.data.slug, b);
-  }
-}
-const briefs = Array.from(latestBySlug.values()).sort(
+// One file per slug now (briefs/render.py overwrites <eco>/<slug>.md each
+// run), so no dedupe pass is needed — sort straight by score.
+const briefs = [...all].sort(
   (a, b) => b.data.score.total - a.data.score.total,
 );
 
@@ -62,7 +55,7 @@ const labels = Object.fromEntries(columns.map((c) => [c.name, c.label]));
 ---
 
 <Base title="biibaa">
-  <span slot="header-right">{rows.length} briefs · {all.length} total dated</span>
+  <span slot="header-right">{rows.length} briefs</span>
 
   <div
     x-data={`triage(${JSON.stringify({ rows, ecosystems, kinds, tags, columns, labels })})`}

--- a/src/biibaa/adapters/e18e.py
+++ b/src/biibaa/adapters/e18e.py
@@ -16,6 +16,7 @@ exist they're collapsed into Replacement.to_purls.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterator
 from typing import Any
 
@@ -28,6 +29,10 @@ from biibaa.domain import Replacement
 log = structlog.get_logger(__name__)
 
 RAW_BASE = "https://raw.githubusercontent.com/e18e/module-replacements/main/manifests"
+# GitHub blob URL prefix — used to deep-link a from-package's manifest entry
+# (with `#L<line>` anchor) so brief citations point at the exact mapping
+# rather than the whole 5k-line manifest file.
+BLOB_BASE = "https://github.com/e18e/module-replacements/blob/main/manifests"
 
 # (manifest filename, axis to record on emitted Replacements)
 _MANIFESTS: tuple[tuple[str, str], ...] = (
@@ -75,20 +80,21 @@ class E18eReplacementsSource:
     def __init__(self, *, client: httpx.Client | None = None) -> None:
         self._client = client or make_client(timeout=30.0)
 
-    def _load(self, filename: str) -> dict[str, Any]:
+    def _load(self, filename: str) -> tuple[dict[str, Any], str]:
         url = f"{RAW_BASE}/{filename}"
         r = self._client.get(url)
         r.raise_for_status()
-        return r.json()
+        return r.json(), r.text
 
     def fetch(self) -> Iterator[Replacement]:
         for filename, axis in _MANIFESTS:
             log.info("e18e.fetch", manifest=filename, axis=axis)
             try:
-                doc = self._load(filename)
+                doc, raw = self._load(filename)
             except httpx.HTTPError as e:
                 log.warning("e18e.fetch_failed", manifest=filename, error=str(e))
                 continue
+            line_index = _index_mapping_lines(raw)
             mappings: dict[str, dict[str, Any]] = doc.get("mappings", {})
             replacements: dict[str, dict[str, Any]] = doc.get("replacements", {})
             for from_name, mapping in mappings.items():
@@ -107,13 +113,27 @@ class E18eReplacementsSource:
                 ):
                     # No actionable replacement — skip.
                     continue
+                line = line_index.get(from_name)
+                citation_url = (
+                    f"{BLOB_BASE}/{filename}#L{line}"
+                    if line is not None
+                    else f"{BLOB_BASE}/{filename}"
+                )
+                evidence: dict[str, str | int | float] = {
+                    "source": "e18e",
+                    "manifest": filename,
+                    "ids": ",".join(rep_ids),
+                    "citation_url": citation_url,
+                }
+                if line is not None:
+                    evidence["manifest_line"] = line
                 yield Replacement(
                     id=f"e18e:{filename}:{from_name}",
                     from_purl=_purl(from_name),
                     to_purls=[_purl(t) for t in resolved_targets] or [_purl("<native>")],
                     axis=axis,  # type: ignore[arg-type]
                     effort=effort_band,  # type: ignore[arg-type]
-                    evidence={"source": "e18e", "manifest": filename, "ids": ",".join(rep_ids)},
+                    evidence=evidence,
                 )
 
     def close(self) -> None:
@@ -130,3 +150,38 @@ _BAND_RANK: dict[str, int] = {
 
 def _easier(a: str, b: str) -> str:
     return a if _BAND_RANK.get(a, 0) >= _BAND_RANK.get(b, 0) else b
+
+
+# Matches a from-package key inside the `mappings` block: a JSON string at
+# the start of a line (with leading whitespace) followed by `:` and `{`.
+# `re.escape(name)` keeps scoped names like `@scope/name` safe.
+def _mapping_line_pattern(name: str) -> re.Pattern[str]:
+    return re.compile(rf'^\s*"{re.escape(name)}"\s*:\s*\{{', re.MULTILINE)
+
+
+def _index_mapping_lines(raw: str) -> dict[str, int]:
+    """Return `{from_name → 1-based line number}` for every `mappings` key.
+
+    Walks the manifest text line-by-line so we can deep-link each Replacement
+    citation to the exact entry. Stops at the closing `}` of the `mappings`
+    object so a from-name that happens to also be a value (or appears in the
+    `replacements` section) isn't mis-mapped.
+    """
+    result: dict[str, int] = {}
+    in_mappings = False
+    depth = 0
+    key_re = re.compile(r'^\s*"([^"]+)"\s*:\s*\{')
+    for i, line in enumerate(raw.splitlines(), start=1):
+        if not in_mappings:
+            if '"mappings"' in line and ":" in line:
+                in_mappings = True
+                depth = line.count("{") - line.count("}")
+            continue
+        # Match BEFORE updating depth: `"<name>": {` sits at depth 1 even
+        # though the brace on the same line will push depth to 2.
+        if depth == 1 and (m := key_re.match(line)):
+            result[m.group(1)] = i
+        depth += line.count("{") - line.count("}")
+        if depth <= 0:
+            break
+    return result

--- a/src/biibaa/adapters/github_repo.py
+++ b/src/biibaa/adapters/github_repo.py
@@ -91,6 +91,9 @@ _QUERY = """
 query RepoMeta($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     isArchived
+    defaultBranchRef {
+      target { oid }
+    }
     pullRequests(states: MERGED, orderBy: {field: UPDATED_AT, direction: DESC}, first: 1) {
       nodes { mergedAt }
     }
@@ -103,6 +106,16 @@ query RepoMeta($owner: String!, $name: String!) {
 class RepoMeta:
     last_merged_pr_at: datetime | None
     is_archived: bool
+    head_sha: str | None = None
+
+
+@dataclass(frozen=True)
+class DepLocation:
+    """Adapter-level location record (no permalink — pipeline builds the URL
+    once it has the repo + sha + file). `line` is 1-based or None."""
+
+    file: str
+    line: int | None = None
 
 _REPO_RE = re.compile(r"https?://github\.com/([^/]+)/([^/?#]+?)(?:\.git)?/?$")
 
@@ -144,6 +157,10 @@ class GithubRepoSource:
         # Caches the parsed package.json so fetch_direct_deps and bench_info
         # share a single HTTP round-trip per repo. None = fetch/parse failed.
         self._pkg_cache: dict[tuple[str, str], dict | None] = {}
+        # Raw text of the same package.json — kept alongside the parsed dict
+        # so fetch_dependency_locations can find the line where each dep is
+        # declared without a second fetch.
+        self._pkg_text_cache: dict[tuple[str, str], str | None] = {}
         # Tracks whether package.json was definitively absent (404) vs failed
         # for some other reason (parse error, network blip). Lets the
         # transitive-filter distinguish "not a JS project" from "transient".
@@ -152,6 +169,12 @@ class GithubRepoSource:
         # from `pnpm-lock.yaml`. None = fetch or parse failed (caller falls
         # back to MONOREPO_SENTINEL).
         self._lockfile_cache: dict[tuple[str, str], set[str] | None] = {}
+        # Per-name workspace paths from the same lockfile parse, e.g.
+        # `{"lodash": ["packages/api", "packages/web"]}`. Populated lazily
+        # alongside `_lockfile_cache`.
+        self._lockfile_locations_cache: dict[
+            tuple[str, str], dict[str, list[str]] | None
+        ] = {}
         # Caches whether ANY root lockfile exists. None = couldn't tell
         # (transient error). True/False are definitive.
         self._has_root_lockfile_cache: dict[tuple[str, str], bool | None] = {}
@@ -196,8 +219,13 @@ class GithubRepoSource:
             merged_at = datetime.fromisoformat(
                 nodes[0]["mergedAt"].replace("Z", "+00:00")
             )
+        head_sha: str | None = None
+        if (target := (repo.get("defaultBranchRef") or {}).get("target")):
+            head_sha = target.get("oid")
         meta = RepoMeta(
-            last_merged_pr_at=merged_at, is_archived=bool(repo.get("isArchived"))
+            last_merged_pr_at=merged_at,
+            is_archived=bool(repo.get("isArchived")),
+            head_sha=head_sha,
         )
         self._cache[parsed] = meta
         return meta
@@ -231,10 +259,12 @@ class GithubRepoSource:
             r = self._client.get(url, headers=self._headers())
             if r.status_code == 404:
                 self._pkg_cache[parsed] = None
+                self._pkg_text_cache[parsed] = None
                 self._pkg_missing[parsed] = True
                 return None
             r.raise_for_status()
-            payload = json.loads(r.text)
+            text = r.text
+            payload = json.loads(text)
         except (httpx.HTTPError, json.JSONDecodeError, ValueError) as e:
             log.warning(
                 "github_repo.fetch_pkg_failed",
@@ -242,13 +272,16 @@ class GithubRepoSource:
                 error=str(e),
             )
             self._pkg_cache[parsed] = None
+            self._pkg_text_cache[parsed] = None
             self._pkg_missing[parsed] = False
             return None
         if not isinstance(payload, dict):
             self._pkg_cache[parsed] = None
+            self._pkg_text_cache[parsed] = None
             self._pkg_missing[parsed] = False
             return None
         self._pkg_cache[parsed] = payload
+        self._pkg_text_cache[parsed] = text
         self._pkg_missing[parsed] = False
         return payload
 
@@ -308,23 +341,30 @@ class GithubRepoSource:
             return None
         if not isinstance(doc, dict):
             self._lockfile_cache[parsed] = None
+            self._lockfile_locations_cache[parsed] = None
             return None
         importers = doc.get("importers")
         if not isinstance(importers, dict):
             self._lockfile_cache[parsed] = None
+            self._lockfile_locations_cache[parsed] = None
             return None
         names: set[str] = set()
-        for imp in importers.values():
+        per_name: dict[str, list[str]] = {}
+        for ws_path, imp in importers.items():
             if not isinstance(imp, dict):
                 continue
             for section in _PNPM_DEP_SECTIONS:
                 m = imp.get(section)
                 if isinstance(m, dict):
-                    names |= set(m.keys())
+                    for dep_name in m:
+                        names.add(dep_name)
+                        per_name.setdefault(dep_name, []).append(str(ws_path))
         if not names:
             self._lockfile_cache[parsed] = None
+            self._lockfile_locations_cache[parsed] = None
             return None
         self._lockfile_cache[parsed] = names
+        self._lockfile_locations_cache[parsed] = per_name
         return names
 
     def fetch_direct_deps(self, *, repo_url: str) -> set[str] | None:
@@ -386,6 +426,70 @@ class GithubRepoSource:
             names |= set(dev_deps.keys())
         return names
 
+    def fetch_dependency_locations(
+        self, *, repo_url: str, names: set[str]
+    ) -> dict[str, list[DepLocation]]:
+        """Return per-name source locations of those deps in the dependent.
+
+        Single-package repos: one `DepLocation(file="package.json", line=N)`
+        per requested name (when found). Line is the 1-based line in the
+        repo's HEAD `package.json` where `"<name>":` is declared under
+        `dependencies` / `devDependencies` / `optionalDependencies` /
+        `peerDependencies`.
+
+        Monorepos with a parseable `pnpm-lock.yaml`: one DepLocation per
+        workspace whose `package.json` declares the dep. `line` is `None`
+        because resolving the per-workspace line would cost an extra HTTP
+        fetch per workspace.
+
+        Names not found in the dependent are absent from the result. Repos
+        without a parseable manifest return `{}`. The pipeline pairs this
+        with the repo's HEAD SHA to build pinned permalinks for the brief.
+        """
+        parsed = _parse_repo_url(repo_url)
+        if not parsed:
+            return {}
+        payload = self._fetch_pkg_json(repo_url=repo_url)
+        if payload is None:
+            return {}
+
+        ws = payload.get("workspaces")
+        is_monorepo = (isinstance(ws, list) and bool(ws)) or (
+            isinstance(ws, dict)
+            and isinstance(ws.get("packages"), list)
+            and bool(ws["packages"])
+        )
+        if is_monorepo:
+            self._fetch_pnpm_lockfile_deps(repo_url=repo_url)
+            per_name = self._lockfile_locations_cache.get(parsed) or {}
+            out: dict[str, list[DepLocation]] = {}
+            for name in names:
+                paths = per_name.get(name)
+                if not paths:
+                    continue
+                # Workspace paths are relative; normalize "" / "." to the
+                # repo-root package.json. Otherwise append `/package.json`.
+                seen: set[str] = set()
+                locs: list[DepLocation] = []
+                for p in paths:
+                    file = (
+                        "package.json"
+                        if p in ("", ".")
+                        else f"{p.rstrip('/')}/package.json"
+                    )
+                    if file in seen:
+                        continue
+                    seen.add(file)
+                    locs.append(DepLocation(file=file, line=None))
+                if locs:
+                    out[name] = locs
+            return out
+
+        text = self._pkg_text_cache.get(parsed)
+        if not text:
+            return {}
+        return _scan_package_json_lines(text, names)
+
     def bench_info(self, *, repo_url: str) -> tuple[bool, str | None]:
         """Detect runnable-benchmark signals in the repo's HEAD package.json.
 
@@ -428,3 +532,49 @@ class GithubRepoSource:
 
     def close(self) -> None:
         self._client.close()
+
+
+# Sections we consider "directly declared" — same set as the lockfile parser
+# above. Restricting the line scan to these blocks avoids false positives
+# from `resolutions`, `overrides`, or string values elsewhere in the file.
+_PKG_DEP_SECTION_RE = re.compile(
+    r'^\s*"(?P<section>dependencies|devDependencies|optionalDependencies|peerDependencies)"\s*:\s*\{',
+    re.MULTILINE,
+)
+
+
+def _scan_package_json_lines(
+    text: str, names: set[str]
+) -> dict[str, list["DepLocation"]]:
+    """Find the line where each requested name is declared in `text`.
+
+    Walks the file once, tracking when we're inside a dependency section
+    (dependencies / devDependencies / optionalDependencies /
+    peerDependencies). Inside a section, the first key matching `names` at
+    that section's depth is recorded. Only the first occurrence per name is
+    kept — duplicate declarations across sections are unusual and the
+    reviewer can find others by reading the file.
+    """
+    found: dict[str, list[DepLocation]] = {}
+    if not names:
+        return found
+    in_section: str | None = None
+    section_depth = 0
+    depth = 0
+    key_re = re.compile(r'^\s*"([^"]+)"\s*:')
+    for i, line in enumerate(text.splitlines(), start=1):
+        if in_section is None:
+            if (m := _PKG_DEP_SECTION_RE.match(line)):
+                in_section = m.group("section")
+                section_depth = line.count("{") - line.count("}")
+                depth = section_depth
+            continue
+        if depth == section_depth and (m := key_re.match(line)):
+            key = m.group(1)
+            if key in names and key not in found:
+                found[key] = [DepLocation(file="package.json", line=i)]
+        depth += line.count("{") - line.count("}")
+        if depth < section_depth:
+            in_section = None
+            section_depth = 0
+    return found

--- a/src/biibaa/briefs/render.py
+++ b/src/biibaa/briefs/render.py
@@ -63,7 +63,12 @@ def _build_tags(brief: Brief) -> list[str]:
 
 
 def _build_citations(opportunities: list[Opportunity]) -> list[dict[str, str]]:
-    """Flat citations list — what a website needs to render evidence links."""
+    """Flat citations list — what a website needs to render evidence links.
+
+    e18e citations deep-link to the from-package's specific entry in the
+    manifest (`citation_url` carries `#L<line>` when known) so reviewers
+    land on the actual mapping rather than scrolling a 5k-line JSON file.
+    """
     out: list[dict[str, str]] = []
     seen: set[tuple[str, str]] = set()
     for opp in opportunities:
@@ -75,17 +80,31 @@ def _build_citations(opportunities: list[Opportunity]) -> list[dict[str, str]]:
                 out.append({"type": "advisory", "id": opp.advisory.id, "url": url})
         if opp.replacement:
             manifest = opp.replacement.evidence.get("manifest")
-            if isinstance(manifest, str):
-                url = (
-                    "https://github.com/e18e/module-replacements/blob/main/manifests/"
-                    f"{manifest}"
+            if not isinstance(manifest, str):
+                continue
+            citation_url = opp.replacement.evidence.get("citation_url")
+            url = (
+                citation_url
+                if isinstance(citation_url, str)
+                else f"https://github.com/e18e/module-replacements/blob/main/manifests/{manifest}"
+            )
+            from_name = opp.replacement.from_purl.removeprefix("pkg:npm/")
+            citation_id = f"{manifest}#{from_name}"
+            key = ("e18e-replacement", citation_id)
+            if key not in seen:
+                seen.add(key)
+                out.append(
+                    {"type": "e18e-replacement", "id": citation_id, "url": url}
                 )
-                key = ("e18e-replacement", manifest)
-                if key not in seen:
-                    seen.add(key)
-                    out.append(
-                        {"type": "e18e-replacement", "id": manifest, "url": url}
-                    )
+        for loc in opp.dependency_locations:
+            anchor = f"#L{loc.line}" if loc.line is not None else ""
+            cid = f"{loc.file}{anchor}"
+            key = ("dependency-location", cid)
+            if key not in seen:
+                seen.add(key)
+                out.append(
+                    {"type": "dependency-location", "id": cid, "url": loc.url}
+                )
     return out
 
 
@@ -171,7 +190,14 @@ def render_brief(brief: Brief) -> str:
 
 
 def write_brief(brief: Brief, out_dir: Path) -> Path:
+    """Write the brief as `<out_dir>/<slug>.md`, overwriting any prior run.
+
+    Each project keeps a single file. The previous date-suffixed scheme
+    (`<slug>/<date>.md`) accumulated stale files for projects no longer
+    eligible — overwriting in place makes the on-disk set match the
+    latest run's eligible-projects set.
+    """
     out_dir.mkdir(parents=True, exist_ok=True)
-    path = out_dir / f"{brief.run_at.strftime('%Y-%m-%d')}.md"
+    path = out_dir / f"{brief.slug}.md"
     path.write_text(render_brief(brief))
     return path

--- a/src/biibaa/briefs/templates/brief.md.j2
+++ b/src/biibaa/briefs/templates/brief.md.j2
@@ -20,7 +20,11 @@
 - **Replace**: `{{ opp.replacement.from_purl | replace('pkg:npm/', '') }}` → {% for t in opp.replacement.to_purls %}`{{ t | replace('pkg:npm/', '') }}`{{ ', ' if not loop.last else '' }}{% endfor %}
 
 - **Effort band**: {{ opp.replacement.effort }}
-- **Evidence**: e18e [module-replacements](https://github.com/e18e/module-replacements) · manifest `{{ opp.replacement.evidence.manifest }}`
+- **Evidence**: e18e [module-replacements](https://github.com/e18e/module-replacements) · manifest [{{ opp.replacement.evidence.manifest }}{{ ('#L' ~ opp.replacement.evidence.manifest_line) if opp.replacement.evidence.manifest_line else '' }}]({{ opp.replacement.evidence.citation_url or ('https://github.com/e18e/module-replacements/blob/main/manifests/' ~ opp.replacement.evidence.manifest) }})
+{% if opp.dependency_locations %}
+- **Found in**: {% for loc in opp.dependency_locations %}[{{ loc.file }}{{ ('#L' ~ loc.line) if loc.line else '' }}]({{ loc.url }}){{ ', ' if not loop.last else '' }}{% endfor %}
+
+{% endif %}
 {% endif %}
 - **Effort score**: {{ "%.0f"|format(opp.effort) }} / 100 (high = easy)
 - **Impact score**: {{ "%.0f"|format(opp.impact) }} / 100

--- a/src/biibaa/domain/__init__.py
+++ b/src/biibaa/domain/__init__.py
@@ -1,6 +1,7 @@
 from biibaa.domain.models import (
     Advisory,
     Brief,
+    DependencyLocation,
     Opportunity,
     OpportunityKind,
     Project,
@@ -10,6 +11,7 @@ from biibaa.domain.models import (
 __all__ = [
     "Advisory",
     "Brief",
+    "DependencyLocation",
     "Opportunity",
     "OpportunityKind",
     "Project",

--- a/src/biibaa/domain/models.py
+++ b/src/biibaa/domain/models.py
@@ -55,12 +55,29 @@ class Replacement(_Frozen):
     evidence: dict[str, str | int | float] = Field(default_factory=dict)
 
 
+class DependencyLocation(_Frozen):
+    """Where a flagged dependency is declared in the dependent's source.
+
+    `file` is the repo-relative path (e.g. `package.json` or
+    `packages/foo/package.json`). `line` is 1-based; `None` when we know
+    the file but not the exact line (monorepo workspaces parsed from
+    `pnpm-lock.yaml`, where we'd have to fetch each workspace's
+    `package.json` to find the line). `url` is a permalink pinned to a
+    commit SHA so the link doesn't rot when HEAD moves.
+    """
+
+    file: str
+    line: int | None = None
+    url: str
+
+
 class Opportunity(_Frozen):
     id: str
     kind: OpportunityKind
     project: Project
     advisory: Advisory | None = None
     replacement: Replacement | None = None
+    dependency_locations: list[DependencyLocation] = Field(default_factory=list)
     impact: float
     effort: float
     score: float

--- a/src/biibaa/pipeline/run.py
+++ b/src/biibaa/pipeline/run.py
@@ -27,12 +27,20 @@ from biibaa.adapters.github_advisories import GithubAdvisorySource
 from biibaa.adapters.github_repo import (
     MONOREPO_SENTINEL,
     NOT_JS_SENTINEL,
+    DepLocation,
     GithubRepoSource,
 )
 from biibaa.adapters.npm_downloads import NpmDownloadsSource
 from biibaa.adapters.npm_registry import NpmRegistrySource
 from biibaa.briefs.render import write_brief
-from biibaa.domain import Advisory, Brief, Opportunity, Project, Replacement
+from biibaa.domain import (
+    Advisory,
+    Brief,
+    DependencyLocation,
+    Opportunity,
+    Project,
+    Replacement,
+)
 from biibaa.ports.dependents import Dependent, DependentsSource
 from biibaa.scoring import (
     REPLACEMENT_EFFORT_SCORE,
@@ -54,6 +62,12 @@ class _ProjectFindings:
     advisories: list[Advisory] = field(default_factory=list)
     replacements: list[Replacement] = field(default_factory=list)
     repo_url: str | None = None
+    # Per-replacement.from_purl → adapter-level locations within the
+    # dependent's repo. Built during fan-out (one call per dependent
+    # reusing the cached package.json text), then converted to
+    # `DependencyLocation` records with pinned-SHA URLs at opportunity
+    # construction time.
+    locations_by_from_purl: dict[str, list[DepLocation]] = field(default_factory=dict)
 
 
 def _project_name_from_purl(purl: str) -> str:
@@ -126,8 +140,38 @@ def _vuln_opportunity(
     )
 
 
+def _build_dependency_locations(
+    *,
+    repo_url: str | None,
+    head_sha: str | None,
+    locations: list[DepLocation],
+) -> list[DependencyLocation]:
+    """Convert adapter-level locations into pinned-SHA permalinks.
+
+    Falls back to `HEAD` when the SHA is unknown (e.g. GraphQL miss). Repos
+    without a known repo_url get no locations — we have no base for the
+    permalink. Empty list when there are no input locations.
+    """
+    if not repo_url or not locations:
+        return []
+    base = repo_url.rstrip("/")
+    ref = head_sha or "HEAD"
+    out: list[DependencyLocation] = []
+    for loc in locations:
+        url = f"{base}/blob/{ref}/{loc.file}"
+        if loc.line is not None:
+            url = f"{url}#L{loc.line}"
+        out.append(DependencyLocation(file=loc.file, line=loc.line, url=url))
+    return out
+
+
 def _replacement_opportunity(
-    *, replacement: Replacement, project: Project, run_at: datetime
+    *,
+    replacement: Replacement,
+    project: Project,
+    run_at: datetime,
+    head_sha: str | None,
+    locations: list[DepLocation],
 ) -> Opportunity:
     pop = popularity(downloads_weekly=project.downloads_weekly, stars=project.stars)
     is_native = any("<native>" in p for p in replacement.to_purls)
@@ -137,6 +181,9 @@ def _replacement_opportunity(
     conf = confidence(last_pr_merged_at=project.last_pr_merged_at, now=run_at)
     score = final_score(impact_value=imp, effort_value=eff, confidence_value=conf)
     kind = "perf-replacement" if replacement.axis == "perf" else "dep-replacement"
+    dep_locations = _build_dependency_locations(
+        repo_url=project.repo_url, head_sha=head_sha, locations=locations
+    )
     return Opportunity(
         id=str(
             uuid.uuid5(uuid.NAMESPACE_URL, f"{project.purl}|{replacement.id}")
@@ -144,6 +191,7 @@ def _replacement_opportunity(
         kind=kind,
         project=project,
         replacement=replacement,
+        dependency_locations=dep_locations,
         impact=imp,
         effort=eff,
         score=score,
@@ -241,7 +289,10 @@ def _fan_out_dependents(
     fanout_top_n: int,
     dependents_per_replacement: int,
     repo_src: GithubRepoSource | None = None,
-) -> list[tuple[Replacement, Dependent]]:
+) -> tuple[
+    list[tuple[Replacement, Dependent]],
+    dict[tuple[str, str], list[DepLocation]],
+]:
     """For the most-popular replacement candidates, pull top dependents.
 
     `fanout_top_n` caps how many e18e mappings we fan out from (ranked by
@@ -272,8 +323,9 @@ def _fan_out_dependents(
         for d in deps:
             candidates.append((r, d))
 
+    locations: dict[tuple[str, str], list[DepLocation]] = {}
     if repo_src is None:
-        return candidates
+        return candidates, locations
 
     out: list[tuple[Replacement, Dependent]] = []
     kept = dropped = unknown = monorepo = not_js = 0
@@ -309,6 +361,14 @@ def _fan_out_dependents(
         if from_name in direct:
             kept += 1
             out.append((rep, dep))
+            # Reuse the cached package.json text / lockfile parse to grab
+            # source locations now — once we leave this loop we'd otherwise
+            # have to rediscover which (rep, dep) pairs are paired up.
+            found = repo_src.fetch_dependency_locations(
+                repo_url=dep.repo_url, names={from_name}
+            )
+            if locs := found.get(from_name):
+                locations[(dep.purl, rep.from_purl)] = locs
             continue
         log.info(
             "fanout.dropped_transitive_only",
@@ -325,7 +385,7 @@ def _fan_out_dependents(
         monorepo=monorepo,
         not_js=not_js,
     )
-    return out
+    return out, locations
 
 
 def run(
@@ -366,8 +426,9 @@ def run(
         log.info("pipeline.replacements_fetched", count=len(replacements))
 
     fanouts: list[tuple[Replacement, Dependent]] = []
+    fanout_locations: dict[tuple[str, str], list[DepLocation]] = {}
     if eco_src and replacements:
-        fanouts = _fan_out_dependents(
+        fanouts, fanout_locations = _fan_out_dependents(
             replacements=replacements,
             eco_src=eco_src,
             downloads_src=downloads_src,
@@ -390,12 +451,15 @@ def run(
         f.replacements.append(rep)
         if dep.repo_url and not f.repo_url:
             f.repo_url = dep.repo_url
+        if locs := fanout_locations.get((dep.purl, rep.from_purl)):
+            f.locations_by_from_purl.setdefault(rep.from_purl, locs)
 
     # Hydrate weekly downloads for every project we'll render.
     package_names = [_project_name_from_purl(p) for p in by_project]
     bulk_downloads = downloads_src.weekly_downloads_bulk(packages=package_names)
 
     projects: dict[str, Project] = {}
+    head_shas: dict[str, str | None] = {}
     for purl, findings in by_project.items():
         name = _project_name_from_purl(purl)
         meta = (
@@ -403,6 +467,7 @@ def run(
             if findings.repo_url
             else None
         )
+        head_shas[purl] = meta.head_sha if meta else None
         # Only read bench info for replacement-driven projects: fan-out has
         # already fetched their package.json so this is a free cache hit.
         # Skipping vuln-only projects keeps the HTTP budget unchanged.
@@ -444,9 +509,16 @@ def run(
             opps.append(_vuln_opportunity(advisory=adv, project=project, run_at=run_at))
         # Per-dependent: dedupe replacements by from_purl so the same swap
         # only appears once even if the dependent showed up in two manifests.
+        head_sha = head_shas.get(purl)
         for rep in _dedupe_replacements(findings.replacements):
             opps.append(
-                _replacement_opportunity(replacement=rep, project=project, run_at=run_at)
+                _replacement_opportunity(
+                    replacement=rep,
+                    project=project,
+                    run_at=run_at,
+                    head_sha=head_sha,
+                    locations=findings.locations_by_from_purl.get(rep.from_purl, []),
+                )
             )
 
         if not opps:
@@ -479,9 +551,21 @@ def run(
 
     paths: list[Path] = []
     for brief in top:
-        paths.append(
-            write_brief(brief, output_dir / brief.project.ecosystem / brief.slug)
-        )
+        paths.append(write_brief(brief, output_dir / brief.project.ecosystem))
+
+    # Sweep stale briefs: any *.md in this ecosystem's dir that we didn't
+    # write this run is from a project no longer eligible (or no longer in
+    # the top-N). Without this step the on-disk set would only ever grow.
+    eco_dir = output_dir / ecosystem
+    if eco_dir.is_dir():
+        kept = {p.resolve() for p in paths}
+        removed = 0
+        for stale in eco_dir.glob("*.md"):
+            if stale.resolve() not in kept:
+                stale.unlink()
+                removed += 1
+        if removed:
+            log.info("pipeline.briefs_swept", removed=removed, ecosystem=ecosystem)
 
     advisory_src.close()
     downloads_src.close()

--- a/tests/test_brief_frontmatter.py
+++ b/tests/test_brief_frontmatter.py
@@ -14,7 +14,14 @@ from pathlib import Path
 import yaml
 
 from biibaa.briefs.render import render_brief, write_brief
-from biibaa.domain import Advisory, Brief, Opportunity, Project, Replacement
+from biibaa.domain import (
+    Advisory,
+    Brief,
+    DependencyLocation,
+    Opportunity,
+    Project,
+    Replacement,
+)
 
 _RUN_AT = datetime(2026, 4, 27, 12, 34, 56, tzinfo=UTC)
 
@@ -224,7 +231,9 @@ def test_frontmatter_citations_dedupe_advisory_and_replacement_links() -> None:
     cites = fm["citations"]
     ids = [c["id"] for c in cites]
     assert ids.count("GHSA-1234") == 1
-    assert ids.count("native.json") == 1
+    # Citation id now carries `<manifest>#<from-name>` so multiple replacements
+    # in the same manifest still produce distinct entries.
+    assert ids.count("native.json#x") == 1
     advisory_cite = next(c for c in cites if c["id"] == "GHSA-1234")
     assert advisory_cite["type"] == "advisory"
     assert advisory_cite["url"] == "https://github.com/advisories/GHSA-1234"
@@ -298,7 +307,7 @@ def test_body_omits_repo_link_when_repo_url_unset() -> None:
     assert "**Repo**" not in body
 
 
-def test_write_brief_still_writes_dated_file(tmp_path: Path) -> None:
+def test_write_brief_uses_slug_filename_and_overwrites(tmp_path: Path) -> None:
     proj = _project()
     rep = Replacement(
         id="r1", from_purl="pkg:npm/x", to_purls=["pkg:npm/<native>"],
@@ -308,11 +317,69 @@ def test_write_brief_still_writes_dated_file(tmp_path: Path) -> None:
 
     path = write_brief(brief, tmp_path)
 
-    assert path.name == "2026-04-27.md"
+    assert path.name == "react-redux.md"
     text = path.read_text()
     fm, body = _split_frontmatter(text)
     assert fm["slug"] == "react-redux"
+
+    # Re-running the same brief overwrites in place — no second file.
+    write_brief(brief, tmp_path)
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["react-redux.md"]
     assert "## Top opportunities" in body
+
+
+def test_dependency_locations_render_in_body_and_citations() -> None:
+    """Replacement opportunities surface where the flagged dep is declared
+    in the dependent's source — pinned-SHA permalinks in the body and
+    structured `dependency-location` citations in the frontmatter so the
+    site can show them as cards."""
+    proj = _project()
+    rep = Replacement(
+        id="r1", from_purl="pkg:npm/moment", to_purls=["pkg:npm/date-fns"],
+        axis="bloat", effort="codemod-available",
+        evidence={"manifest": "preferred.json"},
+    )
+    locs = [
+        DependencyLocation(
+            file="package.json",
+            line=42,
+            url="https://github.com/reduxjs/react-redux/blob/abc123/package.json#L42",
+        ),
+        DependencyLocation(
+            file="packages/web/package.json",
+            line=None,
+            url="https://github.com/reduxjs/react-redux/blob/abc123/packages/web/package.json",
+        ),
+    ]
+    opp = Opportunity(
+        id="o1", kind="dep-replacement", project=proj, replacement=rep,
+        dependency_locations=locs,
+        impact=70.0, effort=90.0, score=78.0, dedupe_key="dk1",
+        first_seen_at=_RUN_AT, last_seen_at=_RUN_AT,
+    )
+    brief = _brief([opp], proj)
+
+    fm, body = _split_frontmatter(render_brief(brief))
+
+    # Body shows a "Found in:" line linking each location.
+    assert "**Found in**" in body
+    assert "package.json#L42" in body
+    assert "/blob/abc123/package.json#L42" in body
+    assert "packages/web/package.json" in body
+    # Trim_blocks strips block-tag trailing newlines aggressively — make
+    # sure the **Found in** line still ends with a real newline before the
+    # next bullet (regression test for the locations-glued-to-effort bug).
+    found_idx = body.index("**Found in**")
+    effort_idx = body.index("**Effort score**")
+    assert found_idx < effort_idx
+    between = body[found_idx:effort_idx]
+    assert ")\n" in between, f"line break missing between Found-in and next bullet: {between!r}"
+
+    # Frontmatter citations list both locations; ids include the line anchor
+    # when known, and the bare path when not.
+    cite_locs = [c for c in fm["citations"] if c["type"] == "dependency-location"]
+    cite_ids = sorted(c["id"] for c in cite_locs)
+    assert cite_ids == ["package.json#L42", "packages/web/package.json"]
 
 
 def test_frontmatter_maintainer_activity_handles_unknown() -> None:

--- a/tests/test_direct_deps_filter.py
+++ b/tests/test_direct_deps_filter.py
@@ -335,7 +335,7 @@ def test_filter_drops_candidate_without_direct_dep(
     )
     downloads = _StubDownloadsSrc({"lodash.snakecase": 5_000_000})
     repo_src = _make_repo_src(httpx.Client())
-    out = _fan_out_dependents(
+    out, _ = _fan_out_dependents(
         replacements=[_replacement("lodash.snakecase")],
         eco_src=eco,  # type: ignore[arg-type]
         downloads_src=downloads,  # type: ignore[arg-type]
@@ -357,7 +357,7 @@ def test_filter_keeps_candidate_with_direct_dep(httpx_mock: HTTPXMock) -> None:
     )
     downloads = _StubDownloadsSrc({"lodash.snakecase": 5_000_000})
     repo_src = _make_repo_src(httpx.Client())
-    out = _fan_out_dependents(
+    out, _ = _fan_out_dependents(
         replacements=[_replacement("lodash.snakecase")],
         eco_src=eco,  # type: ignore[arg-type]
         downloads_src=downloads,  # type: ignore[arg-type]
@@ -382,7 +382,7 @@ def test_filter_keeps_candidate_on_transient_verification_error(
     )
     downloads = _StubDownloadsSrc({"lodash.snakecase": 5_000_000})
     repo_src = _make_repo_src(httpx.Client())
-    out = _fan_out_dependents(
+    out, _ = _fan_out_dependents(
         replacements=[_replacement("lodash.snakecase")],
         eco_src=eco,  # type: ignore[arg-type]
         downloads_src=downloads,  # type: ignore[arg-type]
@@ -413,7 +413,7 @@ def test_filter_drops_candidate_with_no_js_at_root(httpx_mock: HTTPXMock) -> Non
     )
     downloads = _StubDownloadsSrc({"lodash.once": 30_000_000})
     repo_src = _make_repo_src(httpx.Client())
-    out = _fan_out_dependents(
+    out, _ = _fan_out_dependents(
         replacements=[_replacement("lodash.once")],
         eco_src=eco,  # type: ignore[arg-type]
         downloads_src=downloads,  # type: ignore[arg-type]
@@ -447,7 +447,7 @@ def test_filter_keeps_candidate_for_monorepo_root_without_lockfile(
     )
     downloads = _StubDownloadsSrc({"lodash.snakecase": 5_000_000})
     repo_src = _make_repo_src(httpx.Client())
-    out = _fan_out_dependents(
+    out, _ = _fan_out_dependents(
         replacements=[_replacement("lodash.snakecase")],
         eco_src=eco,  # type: ignore[arg-type]
         downloads_src=downloads,  # type: ignore[arg-type]
@@ -496,7 +496,7 @@ def test_filter_drops_transitive_only_dep_in_monorepo_with_pnpm_lock(
     )
     downloads = _StubDownloadsSrc({"stream-buffers": 12_000_000})
     repo_src = _make_repo_src(httpx.Client())
-    out = _fan_out_dependents(
+    out, _ = _fan_out_dependents(
         replacements=[_replacement("stream-buffers")],
         eco_src=eco,  # type: ignore[arg-type]
         downloads_src=downloads,  # type: ignore[arg-type]
@@ -513,7 +513,7 @@ def test_filter_disabled_when_repo_src_is_none() -> None:
         [_dep("transitive-only", "https://github.com/foo/bar")]
     )
     downloads = _StubDownloadsSrc({"lodash.snakecase": 5_000_000})
-    out = _fan_out_dependents(
+    out, _ = _fan_out_dependents(
         replacements=[_replacement("lodash.snakecase")],
         eco_src=eco,  # type: ignore[arg-type]
         downloads_src=downloads,  # type: ignore[arg-type]

--- a/tests/test_e18e.py
+++ b/tests/test_e18e.py
@@ -76,3 +76,56 @@ def test_evidence_records_source_manifest(src: E18eReplacementsSource) -> None:
     moment = next(r for r in out if r.from_purl == "pkg:npm/moment")
     assert moment.evidence["source"] == "e18e"
     assert moment.evidence["manifest"] == "preferred.json"
+
+
+# Multiline manifest text so the line-indexer has real lines to walk —
+# the `json=` fixture shortcut serializes to a single line, which is fine
+# for adapter-shape assertions but useless for line-number tests.
+_PREFERRED_RAW = """\
+{
+  "mappings": {
+    "moment": {
+      "type": "module",
+      "moduleName": "moment",
+      "replacements": ["luxon"]
+    },
+    "lodash.debounce": {
+      "type": "module",
+      "moduleName": "lodash.debounce",
+      "replacements": ["es-toolkit"]
+    }
+  },
+  "replacements": {
+    "luxon": {"id": "luxon", "type": "documented", "replacementModule": "luxon"},
+    "es-toolkit": {"id": "es-toolkit", "type": "documented", "replacementModule": "es-toolkit"}
+  }
+}
+"""
+
+
+def test_citation_url_deep_links_to_from_package_line(httpx_mock: HTTPXMock) -> None:
+    """Each Replacement should carry a `citation_url` with `#L<line>` pointing
+    at the `mappings.<from-name>` entry — links to a 5k-line manifest top
+    are useless for triage."""
+    httpx_mock.add_response(
+        url=f"{RAW_BASE}/preferred.json", text=_PREFERRED_RAW
+    )
+    httpx_mock.add_response(url=f"{RAW_BASE}/native.json", json={"mappings": {}, "replacements": {}})
+    httpx_mock.add_response(url=f"{RAW_BASE}/micro-utilities.json", json={"mappings": {}, "replacements": {}})
+
+    src = E18eReplacementsSource(client=httpx.Client())
+    out = list(src.fetch())
+
+    moment = next(r for r in out if r.from_purl == "pkg:npm/moment")
+    # `"moment":` lives on line 3 of _PREFERRED_RAW.
+    assert moment.evidence["manifest_line"] == 3
+    assert moment.evidence["citation_url"].endswith(
+        "/preferred.json#L3"
+    )
+
+    debounce = next(r for r in out if r.from_purl == "pkg:npm/lodash.debounce")
+    # `"lodash.debounce":` is on line 8 (after moment's 6-line entry block).
+    assert debounce.evidence["manifest_line"] == 8
+    assert debounce.evidence["citation_url"].endswith(
+        "/preferred.json#L8"
+    )

--- a/tests/test_github_repo.py
+++ b/tests/test_github_repo.py
@@ -129,3 +129,99 @@ def test_fetch_meta_shares_cache_across_methods(httpx_mock: HTTPXMock) -> None:
     src.is_archived(repo_url="https://github.com/foo/bar")
     src.last_merged_pr_at(repo_url="https://github.com/foo/bar")
     # No second mock registered — pytest-httpx fails teardown if a 2nd call fired.
+
+
+def test_fetch_meta_returns_head_sha(httpx_mock: HTTPXMock) -> None:
+    """The default-branch HEAD oid is needed to build pinned permalinks for
+    dependency-location citations — without it, links rot when HEAD moves."""
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        method="POST",
+        json={
+            "data": {
+                "repository": {
+                    "isArchived": False,
+                    "defaultBranchRef": {"target": {"oid": "deadbeef" * 5}},
+                    "pullRequests": {"nodes": []},
+                }
+            }
+        },
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    meta = src.fetch_meta(repo_url="https://github.com/foo/bar")
+    assert meta is not None
+    assert meta.head_sha == "deadbeef" * 5
+
+
+def test_fetch_dependency_locations_in_single_package_repo(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """For a non-monorepo, locations carry the line number of each dep's
+    declaration in the root package.json."""
+    pkg_json = (
+        '{\n'
+        '  "name": "demo",\n'
+        '  "dependencies": {\n'
+        '    "moment": "^2.0.0",\n'
+        '    "lodash": "^4.0.0"\n'
+        '  },\n'
+        '  "devDependencies": {\n'
+        '    "vitest": "^1.0.0"\n'
+        '  }\n'
+        '}\n'
+    )
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        text=pkg_json,
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    out = src.fetch_dependency_locations(
+        repo_url="https://github.com/foo/bar", names={"moment", "vitest", "missing"}
+    )
+    assert set(out.keys()) == {"moment", "vitest"}
+    moment = out["moment"][0]
+    assert moment.file == "package.json"
+    assert moment.line == 4
+    vitest = out["vitest"][0]
+    assert vitest.line == 8
+    assert "missing" not in out
+
+
+def test_fetch_dependency_locations_for_monorepo_workspaces(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Monorepos return one location per workspace `package.json` declaring
+    the dep. Line numbers are unknown (would cost a fetch per workspace)."""
+    pkg_json = (
+        '{\n'
+        '  "name": "monorepo-root",\n'
+        '  "private": true,\n'
+        '  "workspaces": ["packages/*"]\n'
+        '}\n'
+    )
+    pnpm_lock = (
+        "lockfileVersion: '9.0'\n"
+        "importers:\n"
+        "  packages/api:\n"
+        "    dependencies:\n"
+        "      moment: 2.0.0\n"
+        "  packages/web:\n"
+        "    dependencies:\n"
+        "      moment: 2.0.0\n"
+        "      react: 18.0.0\n"
+    )
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/package.json",
+        text=pkg_json,
+    )
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/foo/bar/HEAD/pnpm-lock.yaml",
+        text=pnpm_lock,
+    )
+    src = GithubRepoSource(token="x", client=httpx.Client())
+    out = src.fetch_dependency_locations(
+        repo_url="https://github.com/foo/bar", names={"moment"}
+    )
+    files = sorted(loc.file for loc in out["moment"])
+    assert files == ["packages/api/package.json", "packages/web/package.json"]
+    assert all(loc.line is None for loc in out["moment"])


### PR DESCRIPTION
## Summary

Code-only feature PR. Three changes, all aimed at making each brief give a reviewer a clickable path from the finding to the line of code that needs to change.

The on-disk migration of existing dated briefs + removal of stale 04-27-only false positives are split off into **#29** (chore/data). Merge this first; #29 is the data-only follow-up.

### 1. Flat brief output — `<eco>/<slug>.md` (overwrites each run)

- `write_brief` writes `data/briefs/<eco>/<slug>.md` and overwrites the prior run instead of accumulating dated files under `<eco>/<slug>/<date>.md`.
- New sweep step in `pipeline.run`: removes any `.md` in the ecosystem dir not written this run, so projects falling out of eligibility (archived, below the downloads floor, no JS manifest at root) drop off disk automatically.
- Site index drops its dedupe-by-slug pass since each slug now has exactly one file. URLs collapse from `/briefs/npm/<slug>/<date>/` to `/briefs/npm/<slug>/`.

### 2. e18e citations now deep-link to the entry, not the whole manifest

The frontmatter used to look like this — generic, not actionable:

```yaml
citations:
  - type: e18e-replacement
    id: preferred.json
    url: https://github.com/e18e/module-replacements/blob/main/manifests/preferred.json
```

Now reviewers land on the exact mapping:

```yaml
citations:
  - type: e18e-replacement
    id: preferred.json#mkdirp
    url: https://github.com/e18e/module-replacements/blob/main/manifests/preferred.json#L2331
```

Implementation: e18e adapter walks the raw manifest once at fetch time and indexes the line of every `mappings` key. Embedded as `manifest_line` + `citation_url` in `Replacement.evidence`.

### 3. New `DependencyLocation` model — pinned-SHA links to where the dep is declared

Each replacement opportunity now carries `dependency_locations: list[DependencyLocation]` populated during the fan-out filter (zero extra HTTP — reuses the cached `package.json` text and `pnpm-lock.yaml` parse).

- **Single-package repos**: line number of `"<dep>":` declaration in `package.json`. One-pass scan of the dep sections (`dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`).
- **Monorepos with parseable `pnpm-lock.yaml`**: one location per workspace `package.json` declaring the dep. `line` is `None` (would cost a fetch per workspace).
- **Yarn / unparseable monorepos**: no locations (graceful — keeps the brief, just no Found-in line).

URLs pinned to the repo's HEAD commit SHA from `defaultBranchRef.target.oid` (added to the existing `RepoMeta` GraphQL query, no extra round-trip). Falls back to `HEAD` ref when the SHA is unknown.

Brief body gains a `**Found in**:` bullet per replacement opportunity:

```md
- **Evidence**: e18e [module-replacements](...) · manifest [preferred.json#L393](.../preferred.json#L393)
- **Found in**: [package.json#L204](https://github.com/microsoft/vscode/blob/81e19a6.../package.json#L204)
- **Effort score**: 95 / 100 (high = easy)
```

Frontmatter `citations` gains `type: dependency-location` entries. The Astro schema already accepts arbitrary citation types, so no site change is needed.

## Test plan

- [x] `uv run pytest -q` — 117 passing. New tests:
  - `test_citation_url_deep_links_to_from_package_line` (e18e adapter)
  - `test_fetch_meta_returns_head_sha` (github_repo adapter)
  - `test_fetch_dependency_locations_in_single_package_repo` (github_repo adapter)
  - `test_fetch_dependency_locations_for_monorepo_workspaces` (github_repo adapter)
  - `test_dependency_locations_render_in_body_and_citations` (brief renderer)
  - `test_write_brief_uses_slug_filename_and_overwrites` (filename change)
- [x] `npm run build` (in `site/`) — clean.
- [x] Real pipeline run; spot-checked `microsoft/vscode` brief — body contains pinned-SHA `**Found in**: [package.json#L204](.../blob/81e19a.../package.json#L204)` lines and the e18e citation URLs include `#L<line>` anchors.
- [ ] Reviewer: pull, run `uv run biibaa run --top 20`, click through the citations on a couple of resulting briefs.

## History

This PR was originally pushed with two commits that included the data migration. Force-pushed to a single squashed code-only commit so reviewers see only the feature here; the data work moved to #29.
