### PR TITLE
test(warehouse): end-to-end sqlmesh plan smoke + fix audit composition

### DIFF
--- a/.github/workflows/warehouse-smoke.yml
+++ b/.github/workflows/warehouse-smoke.yml
@@ -1,0 +1,45 @@
+name: Warehouse smoke
+
+on:
+  pull_request:
+    paths:
+      - "sqlmesh/**"
+      - "src/biibaa/warehouse/**"
+      - "tests/test_warehouse_landing.py"
+      - "tests/test_sqlmesh_plan.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/warehouse-smoke.yml"
+  push:
+    branches: [main]
+    paths:
+      - "sqlmesh/**"
+      - "src/biibaa/warehouse/**"
+      - "tests/test_warehouse_landing.py"
+      - "tests/test_sqlmesh_plan.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/warehouse-smoke.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      # sqlmesh 0.234.x calls ast.Str (removed in Python 3.14). Pin 3.13
+      # until upstream supports 3.14, then drop the version pin.
+      - name: Run warehouse + sqlmesh smoke
+        run: |
+          uv run --python 3.13 --extra warehouse pytest \
+            tests/test_warehouse_landing.py \
+            tests/test_sqlmesh_plan.py \
+            -v

--- a/sqlmesh/models/staging/stg_advisories.sql
+++ b/sqlmesh/models/staging/stg_advisories.sql
@@ -8,7 +8,7 @@ MODEL (
   grain (id, ingest_date),
   audits (
     not_null(columns := (id, project_purl, ingest_date)),
-    unique_values(columns := (id, ingest_date))
+    unique_combination_of_columns(columns := (id, ingest_date))
   )
 );
 

--- a/tests/test_sqlmesh_plan.py
+++ b/tests/test_sqlmesh_plan.py
@@ -1,0 +1,148 @@
+"""End-to-end smoke: land fixture → ``sqlmesh plan`` → assert the mart materializes.
+
+Catches the wiring bugs that the per-file unit tests can't: model graph
+resolution, macro evaluation against real data, audit assertions on the
+landed Parquet, and DuckDB type compatibility between writer and staging
+SELECT lists.
+
+Skipped when the optional ``warehouse`` extra (sqlmesh + duckdb) isn't
+installed, and on Python 3.14+ until upstream sqlmesh stops referencing
+``ast.Str`` (removed from the stdlib in 3.14).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+# sqlmesh 0.234.x calls ast.Str during model load; that attribute is gone in 3.14.
+# Track upstream — once a release supports 3.14, drop this guard.
+if sys.version_info >= (3, 14):
+    pytest.skip(
+        "sqlmesh 0.234.x incompatible with Python 3.14 (ast.Str removed)",
+        allow_module_level=True,
+    )
+
+duckdb = pytest.importorskip("duckdb")
+pytest.importorskip("sqlmesh")
+
+from sqlmesh.core.config import (  # noqa: E402
+    Config,
+    DuckDBConnectionConfig,
+    GatewayConfig,
+    ModelDefaultsConfig,
+)
+from sqlmesh.core.context import Context  # noqa: E402
+
+from biibaa.domain import Advisory, Project  # noqa: E402
+from biibaa.warehouse import land_advisories, land_projects  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SQLMESH_DIR = REPO_ROOT / "sqlmesh"
+
+
+def _build_config(raw_root: Path, db_path: Path) -> Config:
+    return Config(
+        gateways={
+            "local": GatewayConfig(
+                connection=DuckDBConnectionConfig(database=str(db_path)),
+            ),
+        },
+        default_gateway="local",
+        model_defaults=ModelDefaultsConfig(dialect="duckdb"),
+        variables={"raw_root": str(raw_root)},
+    )
+
+
+def _yesterday() -> date:
+    # The staging models are INCREMENTAL_BY_TIME_RANGE @daily — sqlmesh only
+    # backfills *complete* intervals, so today's partition wouldn't be picked up.
+    return date.today() - timedelta(days=1)
+
+
+def test_sqlmesh_plan_materializes_marts_opportunities(tmp_path: Path) -> None:
+    raw = tmp_path / "raw"
+    db = tmp_path / "warehouse.duckdb"
+    ingest = _yesterday()
+
+    land_advisories(
+        [
+            Advisory(
+                id="GHSA-aaa",
+                project_purl="pkg:npm/foo",
+                severity="high",
+                cvss=8.0,
+                summary="boom",
+                affected_versions="<1.2.3",
+                fixed_versions=["1.2.3"],
+                refs=[],
+                published_at=datetime(2026, 4, 1, tzinfo=UTC),
+                repo_url="https://github.com/foo/foo",
+            ),
+            # Pairs with an archived project below — must drop out of the mart.
+            Advisory(
+                id="GHSA-archived",
+                project_purl="pkg:npm/dead",
+                severity="critical",
+                cvss=9.0,
+                summary="ignored",
+                affected_versions="<1.0.0",
+                fixed_versions=["1.0.0"],
+                refs=[],
+                published_at=datetime(2026, 4, 1, tzinfo=UTC),
+                repo_url="https://github.com/dead/dead",
+            ),
+        ],
+        raw_root=raw,
+        ingest_date=ingest,
+    )
+    land_projects(
+        [
+            Project(
+                purl="pkg:npm/foo",
+                ecosystem="npm",
+                name="foo",
+                repo_url="https://github.com/foo/foo",
+                stars=1234,
+                downloads_weekly=10_000,
+                dependents=500,
+                archived=False,
+            ),
+            Project(
+                purl="pkg:npm/dead",
+                ecosystem="npm",
+                name="dead",
+                repo_url="https://github.com/dead/dead",
+                archived=True,
+            ),
+        ],
+        raw_root=raw,
+        ingest_date=ingest,
+    )
+
+    ctx = Context(paths=[str(SQLMESH_DIR)], config=_build_config(raw, db))
+    ctx.plan(auto_apply=True, no_prompts=True)
+
+    con = duckdb.connect(str(db))
+    rows = con.execute(
+        """
+        SELECT id, kind, project_purl, ecosystem, project_name,
+               advisory_severity, project_dependents, score
+        FROM marts.opportunities
+        ORDER BY id
+        """
+    ).fetchall()
+
+    assert len(rows) == 1, f"archived project should drop out; got {rows}"
+    (oid, kind, purl, eco, name, sev, deps, score) = rows[0]
+    assert oid == "GHSA-aaa"
+    assert kind == "vulnerability-fix"
+    assert purl == "pkg:npm/foo"
+    assert eco == "npm"
+    assert name == "foo"
+    assert sev == "high"
+    assert deps == 500
+    assert 0.0 <= score <= 1.0


### PR DESCRIPTION
## Summary

Pick up the deferred follow-ups from #30 by wiring the SQLMesh skeleton end-to-end. The skeleton existed but was never exercised; running it surfaced two real bugs:

- **`staging.advisories` audit was wrong.** It used `unique_values(columns := (id, ingest_date))`, but the built-in `unique_values` checks each column independently — so any partition with two advisories sharing one date fails the audit. Swap to `unique_combination_of_columns` for proper composite uniqueness. (`marts.opportunities` was correct already since it constrains a single column.)
- **sqlmesh 0.234.x is incompatible with Python 3.14.** It calls `ast.Str`, which Python 3.14 removed. The smoke test skips on 3.14 with a pointer to upstream, and the new CI job pins to 3.13. Heads-up: the project's local `.venv` was on 3.14 and any `--extra warehouse` invocation was already broken there.

## How it works

`tests/test_sqlmesh_plan.py` lands a tiny fixture (one live project + one archived) into a tmp `raw_root`, builds a `Config` pointing at a tmp DuckDB, runs `Context.plan(auto_apply=True, no_prompts=True)`, and asserts:

- `marts.opportunities` materializes one row (archived project drops out via the `COALESCE(p.archived, FALSE) = FALSE` filter)
- the row has the expected `kind`, `project_purl`, `ecosystem`, `severity`, `dependents`
- `score ∈ [0, 1]` (also enforced by the existing `score_in_range` audit)

`.github/workflows/warehouse-smoke.yml` runs the warehouse landing tests + this smoke on PRs touching `sqlmesh/`, `src/biibaa/warehouse/`, the test files, `pyproject.toml`, `uv.lock`, or the workflow itself. Uses `astral-sh/setup-uv` and explicitly `--python 3.13`.

## Test plan

- [x] `uv run --python 3.13 --extra warehouse pytest` — 118 passed, 1 skipped
- [x] `uv run --python 3.13 --extra warehouse pytest tests/test_sqlmesh_plan.py -v` — passes; mart row has `score = 0.6699` (matches `cvss/20 + ln(deps)/ln(100k)*0.5`)
- [x] `uv run ruff check tests/test_sqlmesh_plan.py` — clean
- [ ] CI run on this PR — to be verified once pushed

## Follow-ups (still open from #30 / issue #23)

- Port `src/biibaa/scoring.py` into the `score_opportunity` macro (currently a 2-line stub).
- Land remaining sources (e18e replacements, dependents fan-out).
- More marts (`replacements`, `dependents`) + audits (`no_archived_active_opps`, mart relationships).
- Cross-run opportunity state (`new | acknowledged | resolved | …`).
