### PR TITLE
feat(warehouse): port scoring.py into score_opportunity macro

### DIFF
--- a/sqlmesh/macros/__init__.py
+++ b/sqlmesh/macros/__init__.py
@@ -1,25 +1,74 @@
 from __future__ import annotations
 
-from sqlmesh import macro
-from sqlmesh.core.macros import MacroEvaluator
 from sqlglot import exp
+from sqlmesh.core.macros import MacroEvaluator
+
+from sqlmesh import macro
 
 
 @macro()
 def score_opportunity(
     evaluator: MacroEvaluator,
     cvss: exp.Expression,
-    dependents: exp.Expression,
+    downloads_weekly: exp.Expression,
+    stars: exp.Expression,
+    fixed_versions: exp.Expression,
+    advisory_summary: exp.Expression,
+    last_pr_merged_at: exp.Expression,
 ) -> exp.Expression:
-    """Stub heuristic — port of `scoring.py` lands in a follow-up.
+    """SQL port of ``biibaa.scoring.final_score`` for vulnerability-fix opportunities.
 
-    Score in [0, 1]: half from CVSS (0–10 → 0–0.5), half from a log-scaled
-    dependents fan-out (cap 100k → 0.5). Real heuristic is in `src/biibaa/scoring.py`.
+    Returns a value in ``[0, 1]`` = ``(0.6*impact + 0.25*effort + 0.15*confidence) / 100``,
+    where each sub-score is on the [0, 100] scale per SPEC §6. The canonical Python
+    implementation lives in ``src/biibaa/scoring.py``; ``tests/test_sqlmesh_plan.py``
+    asserts SQL ↔ Python parity on rich fixtures.
+
+    Constants kept inline (rather than `@VAR`) so the macro is self-contained:
+    DOWNLOADS_REF_NPM=1e8, STARS_REF=1e5, blend weights 0.7/0.3 and 0.6/0.25/0.15,
+    confidence window 14d→365d, unknown=30.
     """
-    return exp.maybe_parse(
-        f"LEAST(1.0, "
-        f"  COALESCE(({cvss.sql()}) / 20.0, 0) + "
-        f"  COALESCE(LN(GREATEST(({dependents.sql()}), 1)) / LN(100000) * 0.5, 0)"
-        f")",
-        dialect="duckdb",
+    cvss_sql = cvss.sql()
+    dw_sql = downloads_weekly.sql()
+    stars_sql = stars.sql()
+    fv_sql = fixed_versions.sql()
+    summary_sql = advisory_summary.sql()
+    pr_sql = last_pr_merged_at.sql()
+
+    sql = f"""
+    (
+      (
+        0.6 * (
+          GREATEST(0.0, LEAST(100.0,
+            100.0 * (
+              0.7 * COALESCE(LOG10(1.0 + ({dw_sql})) / LOG10(1.0 + 100000000.0), 0.0)
+              + 0.3 * COALESCE(LOG10(1.0 + ({stars_sql})) / LOG10(1.0 + 100000.0), 0.0)
+            )
+          )) / 100.0
+          * GREATEST(0.0, LEAST(100.0, COALESCE(({cvss_sql}), 5.0) * 10.0))
+        )
+        + 0.25 * (
+          CASE
+            WHEN ({fv_sql}) IS NULL OR LEN({fv_sql}) = 0 THEN 20.0
+            WHEN LOWER(COALESCE(({summary_sql}), '')) LIKE '%breaking%'
+              OR LOWER(COALESCE(({summary_sql}), '')) LIKE '%rewrite%'
+              OR LOWER(COALESCE(({summary_sql}), '')) LIKE '%rearchitect%'
+              OR LOWER(COALESCE(({summary_sql}), '')) LIKE '%removed api%'
+              THEN 60.0
+            WHEN REGEXP_MATCHES(({fv_sql})[1], '^[vV]*[0-9]+([.].*)?$') THEN 95.0
+            ELSE 70.0
+          END
+        )
+        + 0.15 * (
+          CASE
+            WHEN ({pr_sql}) IS NULL THEN 30.0
+            WHEN (EPOCH(NOW()) - EPOCH(({pr_sql}))) / 86400.0 <= 14.0 THEN 100.0
+            WHEN (EPOCH(NOW()) - EPOCH(({pr_sql}))) / 86400.0 >= 365.0 THEN 0.0
+            ELSE 100.0 * (
+              1.0 - ((EPOCH(NOW()) - EPOCH(({pr_sql}))) / 86400.0 - 14.0) / 351.0
+            )
+          END
+        )
+      ) / 100.0
     )
+    """
+    return exp.maybe_parse(sql, dialect="duckdb")

--- a/sqlmesh/models/marts/opportunities.sql
+++ b/sqlmesh/models/marts/opportunities.sql
@@ -31,6 +31,7 @@ latest_projects AS (
     downloads_weekly,
     dependents,
     archived,
+    last_pr_merged_at,
     ROW_NUMBER() OVER (PARTITION BY purl ORDER BY ingest_date DESC) AS rn
   FROM staging.projects
 )
@@ -47,7 +48,10 @@ SELECT
   p.stars                                       AS project_stars,
   p.downloads_weekly                            AS project_downloads_weekly,
   p.dependents                                  AS project_dependents,
-  @score_opportunity(a.cvss, p.dependents)      AS score,
+  @score_opportunity(
+    a.cvss, p.downloads_weekly, p.stars,
+    a.fixed_versions, a.summary, p.last_pr_merged_at
+  ) AS score,
   CURRENT_TIMESTAMP                             AS computed_at
 FROM latest_advisories a
 LEFT JOIN latest_projects p

--- a/sqlmesh/models/staging/stg_projects.sql
+++ b/sqlmesh/models/staging/stg_projects.sql
@@ -22,6 +22,7 @@ SELECT
   dependents::BIGINT          AS dependents,
   last_release_at::TIMESTAMP  AS last_release_at,
   last_commit_at::TIMESTAMP   AS last_commit_at,
+  last_pr_merged_at::TIMESTAMP AS last_pr_merged_at,
   archived::BOOLEAN           AS archived,
   has_benchmarks::BOOLEAN     AS has_benchmarks,
   ingest_date::DATE           AS ingest_date

--- a/tests/test_sqlmesh_plan.py
+++ b/tests/test_sqlmesh_plan.py
@@ -38,6 +38,14 @@ from sqlmesh.core.config import (  # noqa: E402
 from sqlmesh.core.context import Context  # noqa: E402
 
 from biibaa.domain import Advisory, Project  # noqa: E402
+from biibaa.scoring import (  # noqa: E402
+    confidence,
+    effort_score,
+    final_score,
+    impact,
+    popularity,
+    severity_score,
+)
 from biibaa.warehouse import land_advisories, land_projects  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -146,3 +154,118 @@ def test_sqlmesh_plan_materializes_marts_opportunities(tmp_path: Path) -> None:
     assert sev == "high"
     assert deps == 500
     assert 0.0 <= score <= 1.0
+
+
+def test_score_opportunity_macro_matches_python_scoring(tmp_path: Path) -> None:
+    """The SQL ``score_opportunity`` macro must produce the same value as
+    ``biibaa.scoring.final_score / 100``. This is the load-bearing parity
+    check — if the macro and Python drift, briefs and the warehouse rank
+    opportunities differently.
+
+    Two fixtures pin determinism around the confidence decay window:
+    one is "fresh" (last_pr_merged_at well within 14d ⇒ confidence=100)
+    and one is "stale" (>365d ⇒ confidence=0), so neither depends on
+    sub-second drift between Python ``datetime.now`` and DuckDB ``NOW()``.
+    """
+    raw = tmp_path / "raw"
+    db = tmp_path / "warehouse.duckdb"
+    ingest = _yesterday()
+    now = datetime.now(UTC)
+
+    fixtures = [
+        # Fresh, drop-in version bump, popular package
+        dict(
+            id="GHSA-fresh",
+            purl="pkg:npm/popular",
+            cvss=7.5,
+            summary="patch fix",
+            fixed_versions=["1.2.3"],
+            stars=10_000,
+            downloads_weekly=5_000_000,
+            last_pr_merged_at=now - timedelta(days=1),
+        ),
+        # Stale, breaking summary (effort=60), low popularity
+        dict(
+            id="GHSA-stale",
+            purl="pkg:npm/quiet",
+            cvss=4.0,
+            summary="breaking rewrite required",
+            fixed_versions=["2.0.0"],
+            stars=10,
+            downloads_weekly=100,
+            last_pr_merged_at=now - timedelta(days=400),
+        ),
+        # NULL-heavy: missing CVSS, empty fix versions, no PR signal — exercises
+        # every COALESCE / IS NULL branch in the macro.
+        dict(
+            id="GHSA-nulls",
+            purl="pkg:npm/sparse",
+            cvss=None,
+            summary="",
+            fixed_versions=[],
+            stars=None,
+            downloads_weekly=None,
+            last_pr_merged_at=None,
+        ),
+    ]
+
+    land_advisories(
+        [
+            Advisory(
+                id=f["id"],
+                project_purl=f["purl"],
+                severity="high",
+                cvss=f["cvss"],
+                summary=f["summary"],
+                affected_versions="<1.0.0",
+                fixed_versions=f["fixed_versions"],
+                refs=[],
+                published_at=datetime(2026, 4, 1, tzinfo=UTC),
+                repo_url=f"https://github.com/{f['purl'].split('/')[-1]}/repo",
+            )
+            for f in fixtures
+        ],
+        raw_root=raw,
+        ingest_date=ingest,
+    )
+    land_projects(
+        [
+            Project(
+                purl=f["purl"],
+                ecosystem="npm",
+                name=f["purl"].split("/")[-1],
+                repo_url=f"https://github.com/{f['purl'].split('/')[-1]}/repo",
+                stars=f["stars"],
+                downloads_weekly=f["downloads_weekly"],
+                last_pr_merged_at=f["last_pr_merged_at"],
+                archived=False,
+            )
+            for f in fixtures
+        ],
+        raw_root=raw,
+        ingest_date=ingest,
+    )
+
+    ctx = Context(paths=[str(SQLMESH_DIR)], config=_build_config(raw, db))
+    ctx.plan(auto_apply=True, no_prompts=True)
+
+    con = duckdb.connect(str(db))
+    sql_scores = dict(
+        con.execute("SELECT id, score FROM marts.opportunities").fetchall()
+    )
+
+    for f in fixtures:
+        pop = popularity(downloads_weekly=f["downloads_weekly"], stars=f["stars"])
+        sev = severity_score(cvss=f["cvss"])
+        eff = effort_score(
+            fixed_versions=f["fixed_versions"], advisory_summary=f["summary"]
+        )
+        imp = impact(pop=pop, sev=sev)
+        conf = confidence(last_pr_merged_at=f["last_pr_merged_at"], now=now)
+        expected = final_score(impact_value=imp, effort_value=eff, confidence_value=conf) / 100.0
+
+        actual = sql_scores[f["id"]]
+        assert abs(actual - expected) < 1e-4, (
+            f"{f['id']}: SQL={actual:.6f} vs Python={expected:.6f} "
+            f"(pop={pop:.2f} sev={sev:.2f} eff={eff:.2f} imp={imp:.2f} conf={conf:.2f})"
+        )


### PR DESCRIPTION
## Summary

Replace the 2-line stub `score_opportunity` macro with a full SQL port of `biibaa.scoring.final_score` for vulnerability-fix opportunities. SPEC §9.A's "Score: SQLMesh SQL + macros — apply popularity + severity + effort heuristics" is no longer a stub.

**Stacked on #31** — this branch contains the smoke-test commit from #31 plus the new score-port commit. Review just `318d644` for what this PR adds.

## What changed

- `sqlmesh/macros/__init__.py` — full port: returns `(0.6*impact + 0.25*effort + 0.15*confidence) / 100 ∈ [0,1]`. Each sub-score on the [0,100] scale per SPEC §6:
  - **popularity**: `100 * (0.7*log10(1+downloads)/log10(1+1e8) + 0.3*log10(1+stars)/log10(1+1e5))`
  - **severity**: `coalesce(cvss, 5) * 10` (NULL → 50, "moderate")
  - **effort**: `case` — empty fix versions → 20, breaking-keyword summary → 60, version-bump-only → 95, else 70
  - **confidence**: linear decay from 100 (≤14d since `last_pr_merged_at`) to 0 (≥365d); NULL → 30
- `sqlmesh/models/staging/stg_projects.sql` — project `last_pr_merged_at` (already in landed Parquet, just unprojected).
- `sqlmesh/models/marts/opportunities.sql` — pass the new args through; add `last_pr_merged_at` to `latest_projects` CTE.

## Tests

`tests/test_sqlmesh_plan.py::test_score_opportunity_macro_matches_python_scoring` lands three fixtures and asserts the SQL macro matches `biibaa.scoring.final_score / 100` within `1e-4`:

1. **Fresh, popular**: cvss=7.5, dl=5M, stars=10k, fix=`[1.2.3]`, pr=1d ago — exercises drop-in effort + full confidence
2. **Stale, breaking**: cvss=4.0, dl=100, stars=10, fix=`[2.0.0]`, summary contains "breaking rewrite", pr=400d ago — exercises breaking-keyword effort + zero confidence
3. **Null-heavy**: cvss=NULL, fix=`[]`, summary=`""`, all popularity NULL, pr=NULL — exercises every COALESCE / IS NULL branch

Two of the three pin determinism by choosing `last_pr_merged_at` outside the [14d, 365d] decay window so test stability doesn't depend on sub-second drift between Python `datetime.now` and DuckDB `NOW()`.

## Test plan

- [x] `uv run --extra warehouse pytest` — 119 passed, 1 skipped
- [x] `uv run --extra warehouse pytest tests/test_sqlmesh_plan.py -v` — both tests pass; SQL ↔ Python parity within 1e-4
- [x] `uv run ruff check` — clean
- [ ] CI run on this PR — to be verified once pushed

## Follow-ups

- Land remaining sources (e18e replacements, dependents fan-out) — unblocks `replacements`, `dependents` marts.
- Cross-run opportunity state (`new | acknowledged | resolved | …`) once we have a real warehouse.
- `no_archived_active_opps`, `unique_combination_of_columns(dedupe_key)` audits.
