### PR TITLE
feat(warehouse): no_archived_active_opps audit on marts.opportunities

### DIFF
--- a/sqlmesh/audits/no_archived_active_opps.sql
+++ b/sqlmesh/audits/no_archived_active_opps.sql
@@ -1,0 +1,21 @@
+AUDIT (
+  name no_archived_active_opps
+);
+
+-- Returns rows iff an opportunity references a project whose *latest* staging
+-- record is archived. The mart's WHERE clause already filters these out — this
+-- audit is the contract: if anyone refactors the join, the filter survives or
+-- the plan fails.
+WITH latest_projects AS (
+  SELECT
+    purl,
+    archived,
+    ROW_NUMBER() OVER (PARTITION BY purl ORDER BY ingest_date DESC) AS rn
+  FROM staging.projects
+)
+SELECT o.id
+FROM @this_model AS o
+JOIN latest_projects AS p
+  ON p.purl = o.project_purl
+ AND p.rn = 1
+WHERE p.archived = TRUE;

--- a/sqlmesh/models/marts/opportunities.sql
+++ b/sqlmesh/models/marts/opportunities.sql
@@ -6,7 +6,8 @@ MODEL (
   audits (
     not_null(columns := (id, kind, project_purl, score)),
     unique_values(columns := (id)),
-    score_in_range
+    score_in_range,
+    no_archived_active_opps
   )
 );
 


### PR DESCRIPTION
## Summary

Promote the "archived projects don't leak into the mart" invariant from a single `WHERE` clause to an enforced contract. The existing filter (`COALESCE(p.archived, FALSE) = FALSE`) is one line easy to lose in a join refactor; a custom audit fails the plan if any opportunity references a project whose latest staging record has `archived = TRUE`.

## What changed

- `sqlmesh/audits/no_archived_active_opps.sql` — custom audit that joins `marts.opportunities` against the latest-row-per-purl projection of `staging.projects` and returns rows iff any opportunity points at an archived project.
- `sqlmesh/models/marts/opportunities.sql` — register the audit alongside `score_in_range`, `not_null`, and `unique_values`.

## Tests

The existing `test_sqlmesh_plan_materializes_marts_opportunities` fixture already covers the audit: it lands `pkg:npm/dead` with `archived=TRUE` plus a paired advisory, and asserts the archived row drops out. The audit now runs on every plan and would fail if the WHERE filter regressed.

## Test plan

- [x] `uv run --extra warehouse pytest tests/test_sqlmesh_plan.py -v` — both tests pass with audit registered
- [x] `uv run --extra warehouse pytest` — 119 passed, 1 skipped
- [ ] CI run on this PR — to be verified once pushed
