### PR TITLE
feat(warehouse): dedupe_key, opportunity_state mart, replacements + dependents landing

### DIFF
--- a/sqlmesh/models/marts/opportunities.sql
+++ b/sqlmesh/models/marts/opportunities.sql
@@ -4,8 +4,8 @@ MODEL (
   cron '@daily',
   grain (id),
   audits (
-    not_null(columns := (id, kind, project_purl, score)),
-    unique_values(columns := (id)),
+    not_null(columns := (id, kind, project_purl, dedupe_key, score)),
+    unique_values(columns := (id, dedupe_key)),
     score_in_range,
     no_archived_active_opps
   )
@@ -39,6 +39,7 @@ latest_projects AS (
 SELECT
   a.id                                          AS id,
   'vulnerability-fix'::TEXT                     AS kind,
+  (a.project_purl || '|' || a.id)::TEXT         AS dedupe_key,
   a.project_purl                                AS project_purl,
   p.ecosystem                                   AS ecosystem,
   p.name                                        AS project_name,

--- a/sqlmesh/models/marts/opportunity_state.sql
+++ b/sqlmesh/models/marts/opportunity_state.sql
@@ -1,0 +1,41 @@
+MODEL (
+  name marts.opportunity_state,
+  kind FULL,
+  cron '@daily',
+  grain dedupe_key,
+  audits (
+    not_null(columns := (dedupe_key, kind, project_purl, first_seen_at, last_seen_at, state)),
+    unique_values(columns := (dedupe_key))
+  )
+);
+
+-- Cross-run lifecycle for each opportunity. ``first_seen_at`` and
+-- ``last_seen_at`` are derived by aggregating over historical staging
+-- partitions: the staging tables are INCREMENTAL_BY_TIME_RANGE on
+-- ``ingest_date``, so MIN/MAX naturally span every run. ``state`` is a
+-- placeholder column for the lifecycle state machine
+-- (new | acknowledged | resolved | rejected | duplicate); v0 leaves
+-- everything as ``new`` until manual transitions are wired up.
+WITH advisory_lifecycle AS (
+  SELECT
+    project_purl,
+    id,
+    MIN(ingest_date) AS first_seen,
+    MAX(ingest_date) AS last_seen,
+    COUNT(DISTINCT ingest_date) AS partition_count
+  FROM staging.advisories
+  GROUP BY project_purl, id
+)
+SELECT
+  o.dedupe_key                                  AS dedupe_key,
+  o.kind                                        AS kind,
+  o.project_purl                                AS project_purl,
+  CAST(alh.first_seen AS TIMESTAMP)             AS first_seen_at,
+  CAST(alh.last_seen AS TIMESTAMP)              AS last_seen_at,
+  alh.partition_count                           AS partition_count,
+  'new'::TEXT                                   AS state,
+  CURRENT_TIMESTAMP                             AS computed_at
+FROM marts.opportunities o
+LEFT JOIN advisory_lifecycle alh
+  ON alh.project_purl = o.project_purl
+ AND alh.id = o.id;

--- a/sqlmesh/models/staging/stg_dependents.sql
+++ b/sqlmesh/models/staging/stg_dependents.sql
@@ -1,0 +1,23 @@
+MODEL (
+  name staging.dependents,
+  kind INCREMENTAL_BY_TIME_RANGE (
+    time_column ingest_date
+  ),
+  start '2026-01-01',
+  cron '@daily',
+  grain (parent_purl, dependent_purl, ingest_date),
+  audits (
+    not_null(columns := (parent_purl, dependent_purl, ingest_date)),
+    unique_combination_of_columns(columns := (parent_purl, dependent_purl, ingest_date))
+  )
+);
+
+SELECT
+  parent_purl::TEXT                       AS parent_purl,
+  dependent_purl::TEXT                    AS dependent_purl,
+  dependent_name::TEXT                    AS dependent_name,
+  dependent_repo_url::TEXT                AS dependent_repo_url,
+  dependent_lifetime_downloads::BIGINT    AS dependent_lifetime_downloads,
+  ingest_date::DATE                       AS ingest_date
+FROM READ_PARQUET(@VAR('raw_root') || '/dependents/dt=*/*.parquet')
+WHERE ingest_date BETWEEN @start_date AND @end_date;

--- a/sqlmesh/models/staging/stg_replacements.sql
+++ b/sqlmesh/models/staging/stg_replacements.sql
@@ -1,0 +1,24 @@
+MODEL (
+  name staging.replacements,
+  kind INCREMENTAL_BY_TIME_RANGE (
+    time_column ingest_date
+  ),
+  start '2026-01-01',
+  cron '@daily',
+  grain (id, from_purl, ingest_date),
+  audits (
+    not_null(columns := (id, from_purl, axis, effort, ingest_date)),
+    unique_combination_of_columns(columns := (id, from_purl, ingest_date))
+  )
+);
+
+SELECT
+  id::TEXT                AS id,
+  from_purl::TEXT         AS from_purl,
+  to_purls::TEXT[]        AS to_purls,
+  axis::TEXT              AS axis,
+  effort::TEXT            AS effort,
+  evidence_json::TEXT     AS evidence_json,
+  ingest_date::DATE       AS ingest_date
+FROM READ_PARQUET(@VAR('raw_root') || '/replacements/dt=*/*.parquet')
+WHERE ingest_date BETWEEN @start_date AND @end_date;

--- a/src/biibaa/warehouse/__init__.py
+++ b/src/biibaa/warehouse/__init__.py
@@ -11,7 +11,15 @@ Importing this module requires the optional `warehouse` extra
 from biibaa.warehouse.landing import (
     DEFAULT_RAW_ROOT,
     land_advisories,
+    land_dependents,
     land_projects,
+    land_replacements,
 )
 
-__all__ = ["DEFAULT_RAW_ROOT", "land_advisories", "land_projects"]
+__all__ = [
+    "DEFAULT_RAW_ROOT",
+    "land_advisories",
+    "land_dependents",
+    "land_projects",
+    "land_replacements",
+]

--- a/src/biibaa/warehouse/landing.py
+++ b/src/biibaa/warehouse/landing.py
@@ -13,6 +13,7 @@ current staging models simply don't project them yet.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable, Sequence
 from datetime import date, datetime
 from pathlib import Path
@@ -20,7 +21,8 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
-from biibaa.domain import Advisory, Project
+from biibaa.domain import Advisory, Project, Replacement
+from biibaa.ports.dependents import Dependent
 
 if TYPE_CHECKING:
     import duckdb
@@ -41,6 +43,25 @@ _ADVISORY_COLUMNS: tuple[tuple[str, str], ...] = (
     ("refs", "TEXT[]"),
     ("published_at", "TIMESTAMP"),
     ("repo_url", "TEXT"),
+    ("ingest_date", "DATE"),
+)
+
+_REPLACEMENT_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("id", "TEXT"),
+    ("from_purl", "TEXT"),
+    ("to_purls", "TEXT[]"),
+    ("axis", "TEXT"),
+    ("effort", "TEXT"),
+    ("evidence_json", "TEXT"),
+    ("ingest_date", "DATE"),
+)
+
+_DEPENDENT_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("parent_purl", "TEXT"),
+    ("dependent_purl", "TEXT"),
+    ("dependent_name", "TEXT"),
+    ("dependent_repo_url", "TEXT"),
+    ("dependent_lifetime_downloads", "BIGINT"),
     ("ingest_date", "DATE"),
 )
 
@@ -117,6 +138,29 @@ def _project_row(proj: Project, ingest_date: date) -> tuple[Any, ...]:
         proj.archived,
         proj.has_benchmarks,
         proj.bench_signal,
+        ingest_date,
+    )
+
+
+def _replacement_row(rep: Replacement, ingest_date: date) -> tuple[Any, ...]:
+    return (
+        rep.id,
+        rep.from_purl,
+        list(rep.to_purls),
+        rep.axis,
+        rep.effort,
+        json.dumps(dict(rep.evidence), sort_keys=True) if rep.evidence else None,
+        ingest_date,
+    )
+
+
+def _dependent_row(parent_purl: str, dep: Dependent, ingest_date: date) -> tuple[Any, ...]:
+    return (
+        parent_purl,
+        dep.purl,
+        dep.name,
+        dep.repo_url,
+        dep.lifetime_downloads,
         ingest_date,
     )
 
@@ -207,6 +251,73 @@ def land_projects(
     )
     log.info(
         "warehouse.projects_landed",
+        path=str(out_path),
+        rows=len(rows),
+        ingest_date=ingest_date.isoformat(),
+    )
+    return out_path
+
+
+def land_replacements(
+    replacements: Iterable[Replacement],
+    *,
+    raw_root: Path = DEFAULT_RAW_ROOT,
+    ingest_date: date | None = None,
+    filename: str = "replacements.parquet",
+) -> Path:
+    """Land replacements at ``<raw_root>/replacements/dt=<ingest_date>/<filename>``.
+
+    See :func:`land_advisories` for semantics. ``Replacement.evidence`` is
+    serialized as JSON in the ``evidence_json`` column since the dict is
+    heterogeneously typed.
+    """
+    ingest_date = ingest_date or date.today()
+    replacements = list(replacements)
+    rows = [_replacement_row(r, ingest_date) for r in replacements]
+    out_path = _partition_path(raw_root, "replacements", ingest_date, filename)
+    _write(
+        table_name="replacements",
+        columns=_REPLACEMENT_COLUMNS,
+        rows=rows,
+        out_path=out_path,
+    )
+    log.info(
+        "warehouse.replacements_landed",
+        path=str(out_path),
+        rows=len(rows),
+        ingest_date=ingest_date.isoformat(),
+    )
+    return out_path
+
+
+def land_dependents(
+    fan_out: dict[str, Iterable[Dependent]],
+    *,
+    raw_root: Path = DEFAULT_RAW_ROOT,
+    ingest_date: date | None = None,
+    filename: str = "dependents.parquet",
+) -> Path:
+    """Land the dependents fan-out as one row per (parent, dependent) pair.
+
+    ``fan_out`` maps each parent ``purl`` to the list of dependents fetched
+    from the configured ``DependentsSource``. Empty fan-out still produces
+    an empty Parquet file with the declared schema.
+    """
+    ingest_date = ingest_date or date.today()
+    rows = [
+        _dependent_row(parent, dep, ingest_date)
+        for parent, deps in fan_out.items()
+        for dep in deps
+    ]
+    out_path = _partition_path(raw_root, "dependents", ingest_date, filename)
+    _write(
+        table_name="dependents",
+        columns=_DEPENDENT_COLUMNS,
+        rows=rows,
+        out_path=out_path,
+    )
+    log.info(
+        "warehouse.dependents_landed",
         path=str(out_path),
         rows=len(rows),
         ingest_date=ingest_date.isoformat(),

--- a/tests/test_sqlmesh_plan.py
+++ b/tests/test_sqlmesh_plan.py
@@ -46,7 +46,12 @@ from biibaa.scoring import (  # noqa: E402
     popularity,
     severity_score,
 )
-from biibaa.warehouse import land_advisories, land_projects  # noqa: E402
+from biibaa.warehouse import (  # noqa: E402
+    land_advisories,
+    land_dependents,
+    land_projects,
+    land_replacements,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SQLMESH_DIR = REPO_ROOT / "sqlmesh"
@@ -69,6 +74,17 @@ def _yesterday() -> date:
     # The staging models are INCREMENTAL_BY_TIME_RANGE @daily — sqlmesh only
     # backfills *complete* intervals, so today's partition wouldn't be picked up.
     return date.today() - timedelta(days=1)
+
+
+def _land_empty_aux(raw_root: Path, ingest_date: date) -> None:
+    """Land empty replacements/dependents so the staging globs match.
+
+    DuckDB ``READ_PARQUET('.../dt=*/*.parquet')`` errors when no files match;
+    the new ``staging.replacements`` and ``staging.dependents`` models would
+    fail without these even though the test only exercises advisories+projects.
+    """
+    land_replacements([], raw_root=raw_root, ingest_date=ingest_date)
+    land_dependents({}, raw_root=raw_root, ingest_date=ingest_date)
 
 
 def test_sqlmesh_plan_materializes_marts_opportunities(tmp_path: Path) -> None:
@@ -130,6 +146,8 @@ def test_sqlmesh_plan_materializes_marts_opportunities(tmp_path: Path) -> None:
         raw_root=raw,
         ingest_date=ingest,
     )
+
+    _land_empty_aux(raw, ingest)
 
     ctx = Context(paths=[str(SQLMESH_DIR)], config=_build_config(raw, db))
     ctx.plan(auto_apply=True, no_prompts=True)
@@ -246,6 +264,8 @@ def test_score_opportunity_macro_matches_python_scoring(tmp_path: Path) -> None:
         ingest_date=ingest,
     )
 
+    _land_empty_aux(raw, ingest)
+
     ctx = Context(paths=[str(SQLMESH_DIR)], config=_build_config(raw, db))
     ctx.plan(auto_apply=True, no_prompts=True)
 
@@ -269,3 +289,64 @@ def test_score_opportunity_macro_matches_python_scoring(tmp_path: Path) -> None:
             f"{f['id']}: SQL={actual:.6f} vs Python={expected:.6f} "
             f"(pop={pop:.2f} sev={sev:.2f} eff={eff:.2f} imp={imp:.2f} conf={conf:.2f})"
         )
+
+
+def test_opportunity_state_aggregates_first_last_seen_across_partitions(
+    tmp_path: Path,
+) -> None:
+    """``marts.opportunity_state`` derives ``first_seen_at`` / ``last_seen_at``
+    by aggregating over historical staging partitions. Land the same advisory
+    on two different ingest_dates and assert the lifecycle row reflects the
+    full span — the cross-run signal we need before adding a state machine.
+    """
+    raw = tmp_path / "raw"
+    db = tmp_path / "warehouse.duckdb"
+    older = date.today() - timedelta(days=5)
+    newer = date.today() - timedelta(days=1)
+
+    advisory_dict = dict(
+        id="GHSA-recurring",
+        project_purl="pkg:npm/foo",
+        severity="high",
+        cvss=7.5,
+        summary="patch fix",
+        affected_versions="<1.2.3",
+        fixed_versions=["1.2.3"],
+        refs=[],
+        published_at=datetime(2026, 4, 1, tzinfo=UTC),
+        repo_url="https://github.com/foo/foo",
+    )
+    project = Project(
+        purl="pkg:npm/foo",
+        ecosystem="npm",
+        name="foo",
+        repo_url="https://github.com/foo/foo",
+        downloads_weekly=10_000,
+        archived=False,
+    )
+
+    for dt in (older, newer):
+        land_advisories([Advisory(**advisory_dict)], raw_root=raw, ingest_date=dt)
+        land_projects([project], raw_root=raw, ingest_date=dt)
+        _land_empty_aux(raw, dt)
+
+    ctx = Context(paths=[str(SQLMESH_DIR)], config=_build_config(raw, db))
+    ctx.plan(auto_apply=True, no_prompts=True)
+
+    con = duckdb.connect(str(db))
+    rows = con.execute(
+        """
+        SELECT dedupe_key, kind, project_purl, first_seen_at, last_seen_at,
+               partition_count, state
+        FROM marts.opportunity_state
+        """
+    ).fetchall()
+    assert len(rows) == 1
+    (key, kind, purl, first_seen, last_seen, count, state) = rows[0]
+    assert key == "pkg:npm/foo|GHSA-recurring"
+    assert kind == "vulnerability-fix"
+    assert purl == "pkg:npm/foo"
+    assert first_seen.date() == older
+    assert last_seen.date() == newer
+    assert count == 2
+    assert state == "new"

--- a/tests/test_warehouse_landing.py
+++ b/tests/test_warehouse_landing.py
@@ -17,8 +17,14 @@ import pytest
 
 duckdb = pytest.importorskip("duckdb")
 
-from biibaa.domain import Advisory, Project  # noqa: E402
-from biibaa.warehouse import land_advisories, land_projects  # noqa: E402
+from biibaa.domain import Advisory, Project, Replacement  # noqa: E402
+from biibaa.ports.dependents import Dependent  # noqa: E402
+from biibaa.warehouse import (  # noqa: E402
+    land_advisories,
+    land_dependents,
+    land_projects,
+    land_replacements,
+)
 
 
 def _advisory(**overrides) -> Advisory:
@@ -145,3 +151,120 @@ def test_land_advisories_idempotent_overwrite(tmp_path: Path) -> None:
         f"SELECT COUNT(*) FROM read_parquet('{out}')"
     ).fetchone()
     assert count == 1
+
+
+def test_land_replacements_writes_typed_columns(tmp_path: Path) -> None:
+    out = land_replacements(
+        [
+            Replacement(
+                id="micro-utilities/is-array",
+                from_purl="pkg:npm/is-array",
+                to_purls=["pkg:npm/array-isarray"],
+                axis="bloat",
+                effort="drop-in",
+                evidence={"saved_bytes": 1234, "note": "trivial swap"},
+            ),
+            Replacement(
+                id="native/util-promisify",
+                from_purl="pkg:npm/util-promisify",
+                to_purls=[],
+                axis="bloat",
+                effort="drop-in",
+            ),
+        ],
+        raw_root=tmp_path,
+        ingest_date=date(2026, 4, 28),
+    )
+    assert out == tmp_path / "replacements" / "dt=2026-04-28" / "replacements.parquet"
+
+    con = duckdb.connect()
+    rows = con.execute(
+        f"SELECT id, from_purl, to_purls, axis, effort, evidence_json, ingest_date "
+        f"FROM read_parquet('{out}') ORDER BY id"
+    ).fetchall()
+    assert len(rows) == 2
+    (id1, from1, to1, axis1, eff1, ev1, dt1) = rows[0]
+    assert id1 == "micro-utilities/is-array"
+    assert from1 == "pkg:npm/is-array"
+    assert to1 == ["pkg:npm/array-isarray"]
+    assert axis1 == "bloat"
+    assert eff1 == "drop-in"
+    assert "saved_bytes" in ev1  # JSON-serialized
+    assert dt1 == date(2026, 4, 28)
+    # Empty evidence → NULL column
+    assert rows[1][5] is None
+
+
+def test_land_replacements_empty_keeps_schema(tmp_path: Path) -> None:
+    out = land_replacements([], raw_root=tmp_path, ingest_date=date(2026, 4, 28))
+    con = duckdb.connect()
+    schema = {
+        name: ddl
+        for name, ddl, *_ in con.execute(
+            f"DESCRIBE SELECT * FROM read_parquet('{out}')"
+        ).fetchall()
+    }
+    assert schema["id"] == "VARCHAR"
+    assert schema["from_purl"] == "VARCHAR"
+    assert schema["to_purls"] == "VARCHAR[]"
+    assert schema["axis"] == "VARCHAR"
+    assert schema["effort"] == "VARCHAR"
+    assert schema["ingest_date"] == "DATE"
+
+
+def test_land_dependents_flattens_fan_out(tmp_path: Path) -> None:
+    out = land_dependents(
+        {
+            "pkg:npm/foo": [
+                Dependent(
+                    name="alpha",
+                    purl="pkg:npm/alpha",
+                    repo_url="https://github.com/alpha/alpha",
+                    lifetime_downloads=1_000_000,
+                ),
+                Dependent(
+                    name="beta",
+                    purl="pkg:npm/beta",
+                    repo_url=None,
+                    lifetime_downloads=None,
+                ),
+            ],
+            "pkg:npm/bar": [
+                Dependent(
+                    name="gamma",
+                    purl="pkg:npm/gamma",
+                    repo_url="https://github.com/gamma/gamma",
+                    lifetime_downloads=42,
+                ),
+            ],
+        },
+        raw_root=tmp_path,
+        ingest_date=date(2026, 4, 28),
+    )
+    assert out == tmp_path / "dependents" / "dt=2026-04-28" / "dependents.parquet"
+
+    con = duckdb.connect()
+    rows = con.execute(
+        f"SELECT parent_purl, dependent_purl, dependent_lifetime_downloads "
+        f"FROM read_parquet('{out}') ORDER BY parent_purl, dependent_purl"
+    ).fetchall()
+    assert rows == [
+        ("pkg:npm/bar", "pkg:npm/gamma", 42),
+        ("pkg:npm/foo", "pkg:npm/alpha", 1_000_000),
+        ("pkg:npm/foo", "pkg:npm/beta", None),
+    ]
+
+
+def test_land_dependents_empty_keeps_schema(tmp_path: Path) -> None:
+    out = land_dependents({}, raw_root=tmp_path, ingest_date=date(2026, 4, 28))
+    con = duckdb.connect()
+    schema = {
+        name: ddl
+        for name, ddl, *_ in con.execute(
+            f"DESCRIBE SELECT * FROM read_parquet('{out}')"
+        ).fetchall()
+    }
+    assert schema["parent_purl"] == "VARCHAR"
+    assert schema["dependent_purl"] == "VARCHAR"
+    assert schema["dependent_lifetime_downloads"] == "BIGINT"
+    assert schema["ingest_date"] == "DATE"


### PR DESCRIPTION
## Summary

Bundle the four next warehouse follow-ups from issue #23 into one PR:

### 1. `dedupe_key` column + unique audit on `marts.opportunities`

`dedupe_key = <project_purl>|<advisory_id>`, mirroring `biibaa.pipeline.run` so the warehouse and Python rank by the same key. Today's `id` (advisory id) is unique on its own, but it collides across opportunity kinds once we add `dep-replacement` and `perf-replacement` — `dedupe_key` future-proofs the unique constraint.

### 2. `marts.opportunity_state` — cross-run lifecycle

New `FULL` mart that aggregates `MIN(ingest_date) → first_seen_at` and `MAX(ingest_date) → last_seen_at` over `staging.advisories`. Because staging is `INCREMENTAL_BY_TIME_RANGE` on `ingest_date`, the aggregate naturally spans every run — no merge / unique-key state machine required for v0. `state` is a placeholder column (`new` for everyone) until manual lifecycle transitions are wired up.

### 3. `land_replacements` + `staging.replacements`

Writer takes an iterable of `Replacement`, writes one row per replacement under `data/raw/replacements/dt=YYYY-MM-DD/replacements.parquet`. `evidence` is serialized as JSON since the dict is heterogeneously typed (`str | int | float`).

### 4. `land_dependents` + `staging.dependents`

Writer takes a `dict[parent_purl, Iterable[Dependent]]` fan-out and flattens to one row per `(parent_purl, dependent_purl)` pair.

## Tests

- **4 new round-trip tests** in `test_warehouse_landing.py` covering schema, empty-partition, NULL handling for replacements + dependents (12 tests pass total).
- **New `test_opportunity_state_aggregates_first_last_seen_across_partitions`** — lands the same advisory under two different ingest dates (`-5d` and `-1d`), runs plan once, asserts the lifecycle row reflects the full span (`first_seen_at = -5d, last_seen_at = -1d, partition_count = 2`). This is the load-bearing cross-run signal.
- The two existing `test_sqlmesh_plan` tests now also land empty replacements + dependents partitions so the new staging globs match.

## Test plan

- [x] `uv run --extra warehouse pytest` — 124 passed, 1 skipped (was 119)
- [x] `uv run --extra warehouse pytest tests/test_sqlmesh_plan.py -v` — 3 tests pass
- [x] `uv run --extra warehouse pytest tests/test_warehouse_landing.py -v` — 9 tests pass
- [x] `uv run ruff check src/biibaa/warehouse/ tests/test_warehouse_landing.py tests/test_sqlmesh_plan.py` — clean
- [ ] CI run on this PR

## Deliberately not in scope

- **Pipeline wiring**: `biibaa.pipeline.run` doesn't call `land_replacements` or `land_dependents` yet. The existing `--land-raw` flag only covers advisories + projects; expanding it is a separate, small follow-up once the call sites are designed (`replacements_by_pkg` collection in the pipeline isn't built today).
- **State transitions**: the `state` column is a placeholder. The lifecycle state machine (`new | acknowledged | resolved | rejected | duplicate`) needs a transitions table or manual annotations — design decision deferred.

## Follow-ups (still open from issue #23)

- Wire `--land-raw` to also call `land_replacements` and `land_dependents`.
- Implement state transitions on `marts.opportunity_state`.
- Multi-ecosystem support (PyPI / Go / etc.) — currently npm-hardcoded in scoring + landing.
- OSV.dev bulk adapter for advisory coverage beyond GHSA.
