### PR TITLE
feat(pipeline): land replacements + dependents under --land-raw

### DIFF
--- a/src/biibaa/pipeline/run.py
+++ b/src/biibaa/pipeline/run.py
@@ -504,11 +504,29 @@ def run(
     # holds the full source-of-truth snapshot — downstream SQLMesh marts can
     # re-derive eligibility without forcing another ingest pass.
     if land_raw:
-        from biibaa.warehouse import land_advisories, land_projects
+        from biibaa.warehouse import (
+            land_advisories,
+            land_dependents,
+            land_projects,
+            land_replacements,
+        )
 
         target_root = raw_root or Path("data/raw")
         land_advisories(advisories, raw_root=target_root)
         land_projects(projects.values(), raw_root=target_root)
+        land_replacements(replacements, raw_root=target_root)
+        # Dependents fan-out keyed by the *source* package (rep.from_purl);
+        # one rep can surface multiple dependents and one source can have
+        # multiple replacement targets, so dedupe per (parent, dependent).
+        fan_out: dict[str, list[Dependent]] = defaultdict(list)
+        seen: set[tuple[str, str]] = set()
+        for rep, dep in fanouts:
+            key = (rep.from_purl, dep.purl)
+            if key in seen:
+                continue
+            seen.add(key)
+            fan_out[rep.from_purl].append(dep)
+        land_dependents(fan_out, raw_root=target_root)
 
     # Build opportunities + briefs.
     briefs: list[Brief] = []

--- a/tests/test_sqlmesh_plan.py
+++ b/tests/test_sqlmesh_plan.py
@@ -72,8 +72,11 @@ def _build_config(raw_root: Path, db_path: Path) -> Config:
 
 def _yesterday() -> date:
     # The staging models are INCREMENTAL_BY_TIME_RANGE @daily — sqlmesh only
-    # backfills *complete* intervals, so today's partition wouldn't be picked up.
-    return date.today() - timedelta(days=1)
+    # backfills *complete* intervals. Use UTC since sqlmesh evaluates interval
+    # boundaries against UTC; ``date.today()`` returns local date and can be
+    # one day ahead of UTC in non-zero timezones (e.g. +08 just past midnight),
+    # making "yesterday" land in an interval that hasn't closed yet.
+    return (datetime.now(UTC) - timedelta(days=1)).date()
 
 
 def _land_empty_aux(raw_root: Path, ingest_date: date) -> None:
@@ -301,8 +304,9 @@ def test_opportunity_state_aggregates_first_last_seen_across_partitions(
     """
     raw = tmp_path / "raw"
     db = tmp_path / "warehouse.duckdb"
-    older = date.today() - timedelta(days=5)
-    newer = date.today() - timedelta(days=1)
+    today_utc = datetime.now(UTC).date()
+    older = today_utc - timedelta(days=5)
+    newer = today_utc - timedelta(days=1)
 
     advisory_dict = dict(
         id="GHSA-recurring",


### PR DESCRIPTION
## Summary

Wire the `land_replacements` and `land_dependents` writers (added in #34) into the `--land-raw` path in `biibaa.pipeline.run`. With this, a single `biibaa run --land-raw` populates all four staging models the warehouse expects:

- `data/raw/advisories/dt=*/`
- `data/raw/projects/dt=*/`
- `data/raw/replacements/dt=*/`  ← new
- `data/raw/dependents/dt=*/`    ← new

The pipeline already collects `replacements: list[Replacement]` and `fanouts: list[tuple[Replacement, Dependent]]` at the landing point — this PR just hands them to the writers.

## How the fan-out is reshaped

`land_dependents` takes `dict[parent_purl, Iterable[Dependent]]`. The pipeline's `fanouts` is a flat list of `(Replacement, Dependent)` pairs. Group by `rep.from_purl` (the package being replaced — the "parent" in the warehouse model) and dedupe on `(parent, dependent)` since one source package can surface across multiple replacement candidates.

## Drive-by test fix

`_yesterday()` previously used `date.today()` (local timezone). Just past local midnight in non-zero offsets (this repo's user is at +08), local-yesterday is the *current* UTC day — and sqlmesh evaluates interval boundaries against UTC, so the "yesterday" partition lands in an interval that hasn't closed yet, leaving staging empty. Compute from `datetime.now(UTC).date()` instead. Same fix to `older` / `newer` in the cross-run aggregation test.

## Test plan

- [x] `uv run --extra warehouse pytest` — 124 passed, 1 skipped
- [x] `uv run ruff check src/biibaa/pipeline/run.py` — clean
- [ ] CI run on this PR

## Follow-ups

- State transitions on `marts.opportunity_state` (lifecycle state machine).
- OSV.dev bulk adapter to expand advisory coverage beyond GHSA.
- Multi-ecosystem (PyPI / Go / etc.) — currently npm-hardcoded in scoring + fan-out.
