### PR TITLE
feat(warehouse): opportunity state machine (transitions log + mart override)

### DIFF
--- a/sqlmesh/audits/valid_opportunity_state.sql
+++ b/sqlmesh/audits/valid_opportunity_state.sql
@@ -1,0 +1,11 @@
+AUDIT (
+  name valid_opportunity_state
+);
+
+-- Returns rows iff ``state`` is NULL or outside the lifecycle vocabulary.
+-- Mirrors ``biibaa.domain.OpportunityState``: keep both lists in sync.
+-- Used by ``marts.opportunity_state``.
+SELECT state
+FROM @this_model
+WHERE state IS NULL
+   OR state NOT IN ('new', 'acknowledged', 'resolved', 'rejected', 'duplicate');

--- a/sqlmesh/audits/valid_to_state.sql
+++ b/sqlmesh/audits/valid_to_state.sql
@@ -1,0 +1,11 @@
+AUDIT (
+  name valid_to_state
+);
+
+-- Returns rows iff ``to_state`` is NULL or outside the lifecycle vocabulary.
+-- Mirrors ``biibaa.domain.OpportunityState``: keep both lists in sync.
+-- Used by ``staging.opportunity_transitions``.
+SELECT to_state
+FROM @this_model
+WHERE to_state IS NULL
+   OR to_state NOT IN ('new', 'acknowledged', 'resolved', 'rejected', 'duplicate');

--- a/sqlmesh/models/marts/opportunity_state.sql
+++ b/sqlmesh/models/marts/opportunity_state.sql
@@ -5,17 +5,16 @@ MODEL (
   grain dedupe_key,
   audits (
     not_null(columns := (dedupe_key, kind, project_purl, first_seen_at, last_seen_at, state)),
-    unique_values(columns := (dedupe_key))
+    unique_values(columns := (dedupe_key)),
+    valid_opportunity_state
   )
 );
 
 -- Cross-run lifecycle for each opportunity. ``first_seen_at`` and
 -- ``last_seen_at`` are derived by aggregating over historical staging
--- partitions: the staging tables are INCREMENTAL_BY_TIME_RANGE on
--- ``ingest_date``, so MIN/MAX naturally span every run. ``state`` is a
--- placeholder column for the lifecycle state machine
--- (new | acknowledged | resolved | rejected | duplicate); v0 leaves
--- everything as ``new`` until manual transitions are wired up.
+-- partitions. ``state`` is the latest entry from
+-- ``staging.opportunity_transitions`` for the dedupe_key, defaulting to
+-- ``'new'`` when no transition has been recorded.
 WITH advisory_lifecycle AS (
   SELECT
     project_purl,
@@ -25,17 +24,36 @@ WITH advisory_lifecycle AS (
     COUNT(DISTINCT ingest_date) AS partition_count
   FROM staging.advisories
   GROUP BY project_purl, id
+),
+latest_transitions AS (
+  SELECT
+    dedupe_key,
+    to_state,
+    transitioned_at,
+    actor,
+    reason,
+    ROW_NUMBER() OVER (
+      PARTITION BY dedupe_key
+      ORDER BY transitioned_at DESC, ingest_date DESC
+    ) AS rn
+  FROM staging.opportunity_transitions
 )
 SELECT
-  o.dedupe_key                                  AS dedupe_key,
-  o.kind                                        AS kind,
-  o.project_purl                                AS project_purl,
-  CAST(alh.first_seen AS TIMESTAMP)             AS first_seen_at,
-  CAST(alh.last_seen AS TIMESTAMP)              AS last_seen_at,
-  alh.partition_count                           AS partition_count,
-  'new'::TEXT                                   AS state,
-  CURRENT_TIMESTAMP                             AS computed_at
+  o.dedupe_key                                    AS dedupe_key,
+  o.kind                                          AS kind,
+  o.project_purl                                  AS project_purl,
+  CAST(alh.first_seen AS TIMESTAMP)               AS first_seen_at,
+  CAST(alh.last_seen AS TIMESTAMP)                AS last_seen_at,
+  alh.partition_count                             AS partition_count,
+  COALESCE(lt.to_state, 'new')::TEXT              AS state,
+  lt.transitioned_at                              AS state_transitioned_at,
+  lt.actor                                        AS state_actor,
+  lt.reason                                       AS state_reason,
+  CURRENT_TIMESTAMP                               AS computed_at
 FROM marts.opportunities o
 LEFT JOIN advisory_lifecycle alh
   ON alh.project_purl = o.project_purl
- AND alh.id = o.id;
+ AND alh.id = o.id
+LEFT JOIN latest_transitions lt
+  ON lt.dedupe_key = o.dedupe_key
+ AND lt.rn = 1;

--- a/sqlmesh/models/staging/stg_opportunity_transitions.sql
+++ b/sqlmesh/models/staging/stg_opportunity_transitions.sql
@@ -1,0 +1,23 @@
+MODEL (
+  name staging.opportunity_transitions,
+  kind INCREMENTAL_BY_TIME_RANGE (
+    time_column ingest_date
+  ),
+  start '2026-01-01',
+  cron '@daily',
+  grain (dedupe_key, transitioned_at, ingest_date),
+  audits (
+    not_null(columns := (dedupe_key, to_state, transitioned_at, ingest_date)),
+    valid_to_state
+  )
+);
+
+SELECT
+  dedupe_key::TEXT          AS dedupe_key,
+  to_state::TEXT            AS to_state,
+  transitioned_at::TIMESTAMP AS transitioned_at,
+  actor::TEXT               AS actor,
+  reason::TEXT              AS reason,
+  ingest_date::DATE         AS ingest_date
+FROM READ_PARQUET(@VAR('raw_root') || '/opportunity_transitions/dt=*/*.parquet')
+WHERE ingest_date BETWEEN @start_date AND @end_date;

--- a/src/biibaa/warehouse/__init__.py
+++ b/src/biibaa/warehouse/__init__.py
@@ -10,16 +10,20 @@ Importing this module requires the optional `warehouse` extra
 
 from biibaa.warehouse.landing import (
     DEFAULT_RAW_ROOT,
+    OpportunityTransition,
     land_advisories,
     land_dependents,
+    land_opportunity_transitions,
     land_projects,
     land_replacements,
 )
 
 __all__ = [
     "DEFAULT_RAW_ROOT",
+    "OpportunityTransition",
     "land_advisories",
     "land_dependents",
+    "land_opportunity_transitions",
     "land_projects",
     "land_replacements",
 ]

--- a/src/biibaa/warehouse/landing.py
+++ b/src/biibaa/warehouse/landing.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -53,6 +54,15 @@ _REPLACEMENT_COLUMNS: tuple[tuple[str, str], ...] = (
     ("axis", "TEXT"),
     ("effort", "TEXT"),
     ("evidence_json", "TEXT"),
+    ("ingest_date", "DATE"),
+)
+
+_TRANSITION_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("dedupe_key", "TEXT"),
+    ("to_state", "TEXT"),
+    ("transitioned_at", "TIMESTAMP"),
+    ("actor", "TEXT"),
+    ("reason", "TEXT"),
     ("ingest_date", "DATE"),
 )
 
@@ -150,6 +160,36 @@ def _replacement_row(rep: Replacement, ingest_date: date) -> tuple[Any, ...]:
         rep.axis,
         rep.effort,
         json.dumps(dict(rep.evidence), sort_keys=True) if rep.evidence else None,
+        ingest_date,
+    )
+
+
+@dataclass(frozen=True)
+class OpportunityTransition:
+    """One lifecycle transition event for an opportunity ``dedupe_key``.
+
+    Append-only event log: many rows per ``dedupe_key`` accumulate over time;
+    the ``marts.opportunity_state`` mart picks the latest by
+    ``transitioned_at``. ``to_state`` should be one of the
+    ``biibaa.domain.OpportunityState`` literals (``new`` | ``acknowledged`` |
+    ``resolved`` | ``rejected`` | ``duplicate``); the staging model audits
+    enforce membership.
+    """
+
+    dedupe_key: str
+    to_state: str
+    transitioned_at: datetime
+    actor: str | None = None
+    reason: str | None = None
+
+
+def _transition_row(t: OpportunityTransition, ingest_date: date) -> tuple[Any, ...]:
+    return (
+        t.dedupe_key,
+        t.to_state,
+        _strip_tz(t.transitioned_at),
+        t.actor,
+        t.reason,
         ingest_date,
     )
 
@@ -318,6 +358,42 @@ def land_dependents(
     )
     log.info(
         "warehouse.dependents_landed",
+        path=str(out_path),
+        rows=len(rows),
+        ingest_date=ingest_date.isoformat(),
+    )
+    return out_path
+
+
+def land_opportunity_transitions(
+    transitions: Iterable[OpportunityTransition],
+    *,
+    raw_root: Path = DEFAULT_RAW_ROOT,
+    ingest_date: date | None = None,
+    filename: str = "transitions.parquet",
+) -> Path:
+    """Land opportunity-state transitions at
+    ``<raw_root>/opportunity_transitions/dt=<ingest_date>/<filename>``.
+
+    Append-only by convention: re-landing the same partition overwrites the
+    file (idempotent), but each call typically holds the *new* transitions
+    for that day. The mart aggregates across all partitions to pick the
+    latest transition per dedupe_key.
+    """
+    ingest_date = ingest_date or date.today()
+    transitions = list(transitions)
+    rows = [_transition_row(t, ingest_date) for t in transitions]
+    out_path = _partition_path(
+        raw_root, "opportunity_transitions", ingest_date, filename
+    )
+    _write(
+        table_name="opportunity_transitions",
+        columns=_TRANSITION_COLUMNS,
+        rows=rows,
+        out_path=out_path,
+    )
+    log.info(
+        "warehouse.transitions_landed",
         path=str(out_path),
         rows=len(rows),
         ingest_date=ingest_date.isoformat(),

--- a/tests/test_sqlmesh_plan.py
+++ b/tests/test_sqlmesh_plan.py
@@ -47,8 +47,10 @@ from biibaa.scoring import (  # noqa: E402
     severity_score,
 )
 from biibaa.warehouse import (  # noqa: E402
+    OpportunityTransition,
     land_advisories,
     land_dependents,
+    land_opportunity_transitions,
     land_projects,
     land_replacements,
 )
@@ -88,6 +90,7 @@ def _land_empty_aux(raw_root: Path, ingest_date: date) -> None:
     """
     land_replacements([], raw_root=raw_root, ingest_date=ingest_date)
     land_dependents({}, raw_root=raw_root, ingest_date=ingest_date)
+    land_opportunity_transitions([], raw_root=raw_root, ingest_date=ingest_date)
 
 
 def test_sqlmesh_plan_materializes_marts_opportunities(tmp_path: Path) -> None:
@@ -354,3 +357,109 @@ def test_opportunity_state_aggregates_first_last_seen_across_partitions(
     assert last_seen.date() == newer
     assert count == 2
     assert state == "new"
+
+
+def test_opportunity_state_applies_latest_transition(tmp_path: Path) -> None:
+    """``marts.opportunity_state.state`` reflects the latest transition for
+    each ``dedupe_key``, defaulting to ``'new'`` when none has been recorded.
+
+    Lands two transitions for the same dedupe_key with different timestamps
+    and asserts the later one wins. A second dedupe_key has no transition;
+    its state must default to ``'new'``.
+    """
+    raw = tmp_path / "raw"
+    db = tmp_path / "warehouse.duckdb"
+    ingest = _yesterday()
+    now = datetime.now(UTC)
+
+    land_advisories(
+        [
+            Advisory(
+                id="GHSA-acked",
+                project_purl="pkg:npm/foo",
+                severity="high",
+                cvss=7.5,
+                summary="patch fix",
+                affected_versions="<1.2.3",
+                fixed_versions=["1.2.3"],
+                refs=[],
+                published_at=datetime(2026, 4, 1, tzinfo=UTC),
+                repo_url="https://github.com/foo/foo",
+            ),
+            Advisory(
+                id="GHSA-untouched",
+                project_purl="pkg:npm/bar",
+                severity="medium",
+                cvss=5.0,
+                summary="patch fix",
+                affected_versions="<2.0.0",
+                fixed_versions=["2.0.0"],
+                refs=[],
+                published_at=datetime(2026, 4, 1, tzinfo=UTC),
+                repo_url="https://github.com/bar/bar",
+            ),
+        ],
+        raw_root=raw,
+        ingest_date=ingest,
+    )
+    land_projects(
+        [
+            Project(
+                purl="pkg:npm/foo",
+                ecosystem="npm",
+                name="foo",
+                repo_url="https://github.com/foo/foo",
+                downloads_weekly=10_000,
+                archived=False,
+            ),
+            Project(
+                purl="pkg:npm/bar",
+                ecosystem="npm",
+                name="bar",
+                repo_url="https://github.com/bar/bar",
+                downloads_weekly=5_000,
+                archived=False,
+            ),
+        ],
+        raw_root=raw,
+        ingest_date=ingest,
+    )
+    land_replacements([], raw_root=raw, ingest_date=ingest)
+    land_dependents({}, raw_root=raw, ingest_date=ingest)
+
+    # Two transitions for foo: an earlier 'acknowledged' then a later
+    # 'resolved'. The later one wins.
+    land_opportunity_transitions(
+        [
+            OpportunityTransition(
+                dedupe_key="pkg:npm/foo|GHSA-acked",
+                to_state="acknowledged",
+                transitioned_at=now - timedelta(hours=2),
+                actor="alice",
+                reason="triaged",
+            ),
+            OpportunityTransition(
+                dedupe_key="pkg:npm/foo|GHSA-acked",
+                to_state="resolved",
+                transitioned_at=now - timedelta(hours=1),
+                actor="bob",
+                reason="patch landed upstream",
+            ),
+        ],
+        raw_root=raw,
+        ingest_date=ingest,
+    )
+
+    ctx = Context(paths=[str(SQLMESH_DIR)], config=_build_config(raw, db))
+    ctx.plan(auto_apply=True, no_prompts=True)
+
+    con = duckdb.connect(str(db))
+    rows = {
+        key: (state, actor, reason)
+        for key, state, actor, reason in con.execute(
+            "SELECT dedupe_key, state, state_actor, state_reason "
+            "FROM marts.opportunity_state"
+        ).fetchall()
+    }
+    assert rows["pkg:npm/foo|GHSA-acked"] == ("resolved", "bob", "patch landed upstream")
+    assert rows["pkg:npm/bar|GHSA-untouched"] == ("new", None, None)

--- a/tests/test_warehouse_landing.py
+++ b/tests/test_warehouse_landing.py
@@ -268,3 +268,59 @@ def test_land_dependents_empty_keeps_schema(tmp_path: Path) -> None:
     assert schema["dependent_purl"] == "VARCHAR"
     assert schema["dependent_lifetime_downloads"] == "BIGINT"
     assert schema["ingest_date"] == "DATE"
+
+
+def test_land_opportunity_transitions_writes_event_log(tmp_path: Path) -> None:
+    from biibaa.warehouse import OpportunityTransition, land_opportunity_transitions
+
+    out = land_opportunity_transitions(
+        [
+            OpportunityTransition(
+                dedupe_key="pkg:npm/foo|GHSA-aaa",
+                to_state="acknowledged",
+                transitioned_at=datetime(2026, 4, 28, 10, 0, tzinfo=UTC),
+                actor="alice",
+                reason="triaged",
+            ),
+            OpportunityTransition(
+                dedupe_key="pkg:npm/foo|GHSA-aaa",
+                to_state="resolved",
+                transitioned_at=datetime(2026, 4, 28, 12, 0, tzinfo=UTC),
+                actor=None,
+                reason=None,
+            ),
+        ],
+        raw_root=tmp_path,
+        ingest_date=date(2026, 4, 28),
+    )
+    assert out == tmp_path / "opportunity_transitions" / "dt=2026-04-28" / "transitions.parquet"
+
+    con = duckdb.connect()
+    rows = con.execute(
+        f"SELECT dedupe_key, to_state, transitioned_at, actor, reason "
+        f"FROM read_parquet('{out}') ORDER BY transitioned_at"
+    ).fetchall()
+    assert len(rows) == 2
+    assert rows[0][1] == "acknowledged"
+    assert rows[0][3] == "alice"
+    assert rows[1][1] == "resolved"
+    assert rows[1][3] is None
+
+
+def test_land_opportunity_transitions_empty_keeps_schema(tmp_path: Path) -> None:
+    from biibaa.warehouse import land_opportunity_transitions
+
+    out = land_opportunity_transitions(
+        [], raw_root=tmp_path, ingest_date=date(2026, 4, 28)
+    )
+    con = duckdb.connect()
+    schema = {
+        name: ddl
+        for name, ddl, *_ in con.execute(
+            f"DESCRIBE SELECT * FROM read_parquet('{out}')"
+        ).fetchall()
+    }
+    assert schema["dedupe_key"] == "VARCHAR"
+    assert schema["to_state"] == "VARCHAR"
+    assert schema["transitioned_at"] == "TIMESTAMP"
+    assert schema["ingest_date"] == "DATE"


### PR DESCRIPTION
## Summary

Wire the opportunity-state lifecycle from the placeholder column it became in #34 to a real event-log model. With this, manual transitions can be recorded, and `marts.opportunity_state.state` reflects the actual lifecycle position rather than a hardcoded `'new'`.

## How it works

**Event log, not state machine:** transitions are append-only — many rows per `dedupe_key` accumulate over time. `marts.opportunity_state` picks the latest by `transitioned_at` (`ROW_NUMBER() PARTITION BY dedupe_key ORDER BY transitioned_at DESC`), defaulting to `'new'` when no transition has been recorded.

```
data/raw/opportunity_transitions/dt=YYYY-MM-DD/transitions.parquet
  ↓ (read_parquet, INCREMENTAL_BY_TIME_RANGE on ingest_date)
staging.opportunity_transitions
  ↓ (window: latest per dedupe_key)
marts.opportunity_state.state
```

## What changed

- **`OpportunityTransition` dataclass + `land_opportunity_transitions` writer** in `biibaa.warehouse`. Schema: `(dedupe_key, to_state, transitioned_at, actor?, reason?, ingest_date)`.
- **`staging.opportunity_transitions`** — `INCREMENTAL_BY_TIME_RANGE` model.
- **Two custom audits** enforcing `domain.OpportunityState` (`new | acknowledged | resolved | rejected | duplicate`):
  - `valid_to_state` on the staging model
  - `valid_opportunity_state` on the mart
- **`marts.opportunity_state` updated** to LEFT JOIN latest transition and surface `state` + `state_transitioned_at` + `state_actor` + `state_reason` for audit trails.

## Tests

- 2 new round-trip tests for the writer (event log + empty schema → 14 landing tests total).
- New `test_opportunity_state_applies_latest_transition` lands two transitions for one `dedupe_key` (`acknowledged` at `now-2h`, then `resolved` at `now-1h`) plus a second untouched dedupe_key, asserts the later transition wins (`resolved`, `actor=bob`, `reason=…`) and the untouched one defaults to `('new', None, None)`.
- `_land_empty_aux` now also lands an empty transitions partition so the new staging glob matches.

## Test plan

- [x] `uv run --extra warehouse pytest` — 127 passed, 1 skipped (was 124)
- [x] `uv run --extra warehouse pytest tests/test_sqlmesh_plan.py -v` — 4 tests pass
- [x] `uv run ruff check src/biibaa/warehouse/ tests/test_warehouse_landing.py tests/test_sqlmesh_plan.py` — clean
- [ ] CI run on this PR

## Deliberately not in scope

- **Auto-transitions** (e.g. "if dedupe_key disappears from `marts.opportunities` for >N days → auto-resolve"). The current FULL mart only sees current opportunities; auto-resolve would need a persisted history of seen dedupe_keys. Future PR.
- **Pipeline integration**: nothing in `biibaa.pipeline` writes transitions. They're meant to be recorded externally (UI, CLI subcommand, manual script). The writer is the foundation.
- **CLI surface** for recording transitions (`biibaa transition <dedupe_key> --to acknowledged`) — not designed yet.

## Follow-ups (still open from issue #23)

- OSV.dev bulk adapter, NVD enrichment, replacements.fyi.
- Multi-ecosystem support (PyPI / Go / etc.) — currently npm-hardcoded.
- Daily-cron pipeline workflow + CI for ruff/mypy/pytest (the warehouse-smoke job is the only CI today).
- `biibaa ingest` / `show` / `brief` CLI subcommands.
