### PR TITLE
fix(advisories): drop briefs when GHSA has a patched sibling package

### DIFF
--- a/src/biibaa/adapters/github_advisories.py
+++ b/src/biibaa/adapters/github_advisories.py
@@ -95,7 +95,11 @@ class GithubAdvisorySource:
             for adv in page:
                 if adv.get("withdrawn_at"):
                     continue
-                for vuln in adv.get("vulnerabilities") or []:
+                vulns = adv.get("vulnerabilities") or []
+                has_patched_sibling = any(
+                    v.get("first_patched_version") for v in vulns
+                )
+                for vuln in vulns:
                     pkg = vuln.get("package") or {}
                     if not pkg.get("name") or pkg.get("ecosystem", "").lower() != ecosystem:
                         continue
@@ -115,6 +119,7 @@ class GithubAdvisorySource:
                         refs=list(adv.get("references") or []),
                         published_at=_parse_published(adv.get("published_at")),
                         repo_url=adv.get("source_code_location") or None,
+                        has_patched_sibling=has_patched_sibling and not fixed,
                     )
                     emitted += 1
                     if emitted >= limit:

--- a/src/biibaa/domain/models.py
+++ b/src/biibaa/domain/models.py
@@ -44,6 +44,11 @@ class Advisory(_Frozen):
     refs: list[str] = Field(default_factory=list)
     published_at: datetime | None = None
     repo_url: str | None = None
+    # True when another package in the same GHSA already has a
+    # `first_patched_version`. Signals that the upstream project has shipped
+    # a fix (typically under a renamed/scoped successor package), so a
+    # contributor PR would be redundant.
+    has_patched_sibling: bool = False
 
 
 class Replacement(_Frozen):

--- a/src/biibaa/pipeline/run.py
+++ b/src/biibaa/pipeline/run.py
@@ -250,6 +250,30 @@ def _drop_outdated_unpatched(
     return kept
 
 
+def _drop_when_sibling_patched(advisories: list[Advisory]) -> list[Advisory]:
+    """Drop unpatched advisories whose GHSA has a patched sibling package.
+
+    GHSA records often pair an abandoned package (e.g. `xmldom`) with a
+    renamed/scoped successor (`@xmldom/xmldom`) that ships the fix. Both
+    point at the same upstream repo, so a contributor PR to that repo is
+    redundant — the work is already done.
+    """
+    kept: list[Advisory] = []
+    dropped = 0
+    for a in advisories:
+        if a.has_patched_sibling:
+            log.info(
+                "advisory.dropped_sibling_patched",
+                ghsa=a.id,
+                purl=a.project_purl,
+            )
+            dropped += 1
+            continue
+        kept.append(a)
+    log.info("advisory.sibling_patched_filter", kept=len(kept), dropped=dropped)
+    return kept
+
+
 def _dedupe_replacements(reps: list[Replacement]) -> list[Replacement]:
     """Same from_purl can appear in multiple manifests — keep the easiest effort."""
     by_from: dict[str, Replacement] = {}
@@ -419,6 +443,7 @@ def run(
         advisory_src.fetch(ecosystem=ecosystem, limit=advisory_limit)
     )
     log.info("pipeline.advisories_fetched", count=len(advisories))
+    advisories = _drop_when_sibling_patched(advisories)
     if registry_src:
         advisories = _drop_outdated_unpatched(advisories, registry_src)
 

--- a/tests/test_advisory_sibling_patched_filter.py
+++ b/tests/test_advisory_sibling_patched_filter.py
@@ -1,0 +1,35 @@
+"""Drop unpatched advisories when a sibling package in the same GHSA is patched."""
+
+from __future__ import annotations
+
+from biibaa.domain import Advisory
+from biibaa.pipeline.run import _drop_when_sibling_patched
+
+
+def _adv(*, ghsa: str, name: str, has_patched_sibling: bool) -> Advisory:
+    return Advisory(
+        id=ghsa,
+        project_purl=f"pkg:npm/{name}",
+        summary="t",
+        has_patched_sibling=has_patched_sibling,
+    )
+
+
+def test_drops_when_sibling_patched() -> None:
+    advisories = [_adv(ghsa="GHSA-xmldom", name="xmldom", has_patched_sibling=True)]
+    assert _drop_when_sibling_patched(advisories) == []
+
+
+def test_keeps_when_no_sibling_patched() -> None:
+    advisories = [_adv(ghsa="GHSA-lonely", name="lonely", has_patched_sibling=False)]
+    out = _drop_when_sibling_patched(advisories)
+    assert [a.id for a in out] == ["GHSA-lonely"]
+
+
+def test_mixed_keeps_only_unpatched_siblings() -> None:
+    advisories = [
+        _adv(ghsa="GHSA-a", name="abandoned", has_patched_sibling=True),
+        _adv(ghsa="GHSA-b", name="standalone", has_patched_sibling=False),
+    ]
+    out = _drop_when_sibling_patched(advisories)
+    assert [a.id for a in out] == ["GHSA-b"]

--- a/tests/test_github_advisories.py
+++ b/tests/test_github_advisories.py
@@ -64,6 +64,35 @@ def test_only_unpatched_emits_packages_without_fix(httpx_mock: HTTPXMock) -> Non
     assert a.project_purl == "pkg:npm/thingy"
     assert a.fixed_versions == []
     assert a.repo_url == "https://github.com/example/thingy"
+    # Sibling `widget` in the same GHSA is patched — flag for downstream filtering.
+    assert a.has_patched_sibling is True
+
+
+def test_has_patched_sibling_false_when_all_unpatched(httpx_mock: HTTPXMock) -> None:
+    fixture = [
+        {
+            "ghsa_id": "GHSA-test-3333-cccc",
+            "summary": "All packages still unpatched",
+            "severity": "high",
+            "cvss_severities": {"cvss_v3": {"score": 7.5}},
+            "vulnerabilities": [
+                {
+                    "package": {"ecosystem": "npm", "name": "lonely"},
+                    "vulnerable_version_range": "<= 0.1.0",
+                    "first_patched_version": None,
+                }
+            ],
+        }
+    ]
+    for sev in ("critical", "high", "medium"):
+        httpx_mock.add_response(
+            url=f"https://api.github.com/advisories?ecosystem=npm&per_page=100&severity={sev}",
+            json=fixture if sev == "high" else [],
+        )
+    src = GithubAdvisorySource(client=httpx.Client())
+    out = list(src.fetch())
+    assert len(out) == 1
+    assert out[0].has_patched_sibling is False
 
 
 def test_legacy_only_unpatched_false_emits_patched(httpx_mock: HTTPXMock) -> None:


### PR DESCRIPTION
## Summary

Drop unpatched advisories when the same GHSA already has a patched sibling package — fixes false-positive briefs like `data/briefs/npm/xmldom.md`, where every listed CVE is "no upstream patch — contribute one" despite the upstream repo having shipped fixes under the renamed scoped package `@xmldom/xmldom`.

GHSA records frequently pair an abandoned package with a renamed/scoped successor (`xmldom` ↔ `@xmldom/xmldom`, both pointing at the same `source_code_location`). Surfacing the unpatched name as a contribution opportunity wastes contributor time — the work is already done upstream.

## How it works

- `Advisory.has_patched_sibling`: new flag on the domain model.
- `GithubAdvisorySource`: scans each GHSA's `vulnerabilities[]` once and sets the flag on every emitted unpatched record where any sibling has a `first_patched_version`.
- `_drop_when_sibling_patched`: new pipeline filter wired before `_drop_outdated_unpatched` in `pipeline/run.py`.

The existing `data/briefs/npm/xmldom.md` will be overwritten / dropped on the next pipeline run.

## Test plan

- [x] `tests/test_github_advisories.py` — extended to assert `has_patched_sibling` on the existing fixture and added a coverage case for the all-unpatched scenario.
- [x] `tests/test_advisory_sibling_patched_filter.py` — new pipeline filter tests (drops, keeps, mixed).
- [x] Full suite green (`uv run --native-tls pytest`): 131 passed, 1 skipped.
